### PR TITLE
Add IoT wifi support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
-.venv
+__pycache__
 .idea
+.venv
+.vscode
+*.egg-info
+build
 docker-compose.yaml

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ router = TplinkRouter('http://192.168.0.1', 'password')
 firmware = router.get_firmware()
 
 # Get status info - returns Status
-full_info = router.get_status()
+status = router.get_status()
 
 # Turn ON guest wifi 2.5G
 router.set_wifi(Wifi.WIFI_GUEST_2G, True)
@@ -139,6 +139,13 @@ finally:
 - TL-WR1043N V5
 
 Please let me know if you have tested integration with one of this or other model. Open an issue with info about router's model, hardware and firmware versions.
+
+## Local Development
+
+- Download this repository.
+- Run `pip install -e path/to/repo`.
+- Make changes to files within the `tplinkrouter6u` directory.
+- Exercise the changes following the "Usage" section above.
 
 ## Thanks To
  - [EncryptionWrapper for TP-Link Archer C6U](https://github.com/ericpignet/home-assistant-tplink_router/pull/42/files) by [@Singleton-95](https://github.com/Singleton-95)

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ finally:
 | clients_total | Total amount of all connected clients | int |
 | guest_2g_enable | Is guest wifi 2.4G enabled | bool |
 | guest_5g_enable | Is guest wifi 5G enabled | bool |
+| iot_2g_enable | Is IoT wifi 2.4G enabled | bool |
+| iot_5g_enable | Is IoT wifi 5G enabled | bool |
 | wifi_2g_enable | Is main wifi 2.4G enabled | bool |
 | wifi_5g_enable | Is main wifi 5G enabled | bool |
 | wan_ipv4_uptime | Internet Uptime | int, None |
@@ -93,7 +95,7 @@ finally:
 ### <a id="device">Device</a>
 | Field | Description | Type |
 | --- |---|---|
-| type | client connection type (2.4G or 5G, guest wifi of main wifi) | [Wifi](#wifi) |
+| type | client connection type (2.4G or 5G, guest wifi or main wifi) | [Wifi](#wifi) |
 | macaddr | client mac address | str |
 | ipaddr | client ip address | str |
 | hostname | client hostname | str |
@@ -104,6 +106,8 @@ finally:
 - Wifi.WIFI_5G - main wifi 5G
 - Wifi.WIFI_GUEST_2G - guest wifi 2.4G
 - Wifi.WIFI_GUEST_5G - guest wifi 5G
+- Wifi.WIFI_IOT_2G - IoT wifi 2.4g
+- Wifi.WIFI_IOT_5G - IoT wifi 5g
 
 
 ## <a id="supports">Supported routers</a>

--- a/tplinkrouterc6u/client.py
+++ b/tplinkrouterc6u/client.py
@@ -144,6 +144,8 @@ class TplinkRouter:
         status.clients_total = status.wired_total + status.wifi_clients_total + status.guest_clients_total
         status.guest_2g_enable = data.get('guest_2g_enable') == 'on'
         status.guest_5g_enable = data.get('guest_5g_enable') == 'on'
+        status.iot_2g_enable = data.get('iot_2g_enable') == 'on'
+        status.iot_5g_enable = data.get('iot_5g_enable') == 'on'
         status.wifi_2g_enable = data.get('wireless_2g_enable') == 'on'
         status.wifi_5g_enable = data.get('wireless_5g_enable') == 'on'
 

--- a/tplinkrouterc6u/client.py
+++ b/tplinkrouterc6u/client.py
@@ -144,8 +144,8 @@ class TplinkRouter:
         status.clients_total = status.wired_total + status.wifi_clients_total + status.guest_clients_total
         status.guest_2g_enable = data.get('guest_2g_enable') == 'on'
         status.guest_5g_enable = data.get('guest_5g_enable') == 'on'
-        status.iot_2g_enable = data.get('iot_2g_enable') == 'on'
-        status.iot_5g_enable = data.get('iot_5g_enable') == 'on'
+        status.iot_2g_enable = data.get('iot_2g_enable') == 'on' if data.get('iot_2g_enable') is not None else None
+        status.iot_5g_enable = data.get('iot_5g_enable') == 'on' if data.get('iot_5g_enable') is not None else None
         status.wifi_2g_enable = data.get('wireless_2g_enable') == 'on'
         status.wifi_5g_enable = data.get('wireless_5g_enable') == 'on'
 

--- a/tplinkrouterc6u/dataclass.py
+++ b/tplinkrouterc6u/dataclass.py
@@ -28,8 +28,8 @@ class Status:
     clients_total: int
     guest_2g_enable: bool
     guest_5g_enable: bool
-    iot_2g_enable: bool
-    iot_5g_enable: bool
+    iot_2g_enable: bool | None
+    iot_5g_enable: bool | None
     wifi_2g_enable: bool
     wifi_5g_enable: bool
     wan_ipv4_uptime: int | None

--- a/tplinkrouterc6u/dataclass.py
+++ b/tplinkrouterc6u/dataclass.py
@@ -28,6 +28,8 @@ class Status:
     clients_total: int
     guest_2g_enable: bool
     guest_5g_enable: bool
+    iot_2g_enable: bool
+    iot_5g_enable: bool
     wifi_2g_enable: bool
     wifi_5g_enable: bool
     wan_ipv4_uptime: int | None

--- a/tplinkrouterc6u/enum.py
+++ b/tplinkrouterc6u/enum.py
@@ -6,3 +6,5 @@ class Wifi(Enum):
     WIFI_5G = 'wireless_5g'
     WIFI_GUEST_2G = 'guest_2g'
     WIFI_GUEST_5G = 'guest_5g'
+    WIFI_IOT_2G = 'iot_2g'
+    WIFI_IOT_5G = 'iot_5g'


### PR DESCRIPTION
Enum values and README updates

I am surprised that this required the "guest" value on https://github.com/AlexandrErohin/TP-Link-Archer-C6U/blob/main/tplinkrouterc6u/client.py#L57 - but it seems to work still.

Tested with Archer AX3000.