### PR TITLE
Pass response contents through _send_data()

### DIFF
--- a/tplinkrouterc6u/client.py
+++ b/tplinkrouterc6u/client.py
@@ -225,7 +225,7 @@ class TplinkRouter:
 
         return {'sign': sign, 'data': encrypted_data}
 
-    def _request(self, callback: Callable) -> None:
+    def _request(self, callback: Callable) -> dict | None:
         if not self.single_request_mode:
             return callback()
 

--- a/tplinkrouterc6u/dataclass.py
+++ b/tplinkrouterc6u/dataclass.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from tplinkrouterc6u.enum import Wifi
 
 


### PR DESCRIPTION
This mimics the behavior of `_get_data()` by moving the response-parsing logic out to `_parse_response()` and using it for both `_get_data()` and `_send_data()`.

Also included type hints.

The benefit here is that responses can be passed all the way up, such as `print(router.set_wifi(Wifi.WIFI_GUEST_5G, True))`.