### PR TITLE
Tp-link C1200 V2 error in request to /admin/smart_network?form=game_accelerator&operation=loadDevice 

### DIFF
--- a/tplinkrouterc6u/client.py
+++ b/tplinkrouterc6u/client.py
@@ -695,6 +695,7 @@ class TplinkC1200Router(TplinkBaseRouter):
             regex_result = re.search('sysauth=(.*);', response.headers['set-cookie'])
             self._sysauth = regex_result.group(1)
             self._logged = True
+            self._smart_network = False
 
         except Exception as e:
             error = "TplinkRouter - C1200 - Cannot authorize! Error - {}; Response - {}".format(e, response.text)


### PR DESCRIPTION
tp link c1200 v2 does not have ```/admin/smart_network?form=game_accelerator&operation=loadDevice```

The router responds with: ```No root node was registered, this usually happens if no module was installed. Install luci-mod-admin-full and retry. If the module is already installed, try removing the /tmp/luci-indexcache file.```

This causes an error, because json is expected.
I added self._smart_network = False to class TplinkC1200Router