### PR TITLE
Add down_speed and up_speed to Device and add data from Deco.

### DIFF
--- a/test/test_client_deco.py
+++ b/test/test_client_deco.py
@@ -246,6 +246,8 @@ class TestTPLinkDecoClient(unittest.TestCase):
         self.assertIsInstance(status.devices[0], Device)
         self.assertEqual(status.devices[0].type, Connection.HOST_5G)
         self.assertEqual(status.devices[0].macaddr, 'CF-51-C9-04-E1-02')
+        self.assertEqual(status.devices[0].down_speed, 3)
+        self.assertEqual(status.devices[0].up_speed, 17)
         self.assertIsInstance(status.devices[0].macaddress, macaddress.EUI48)
         self.assertIsInstance(status.devices[1], Device)
         self.assertEqual(status.devices[1].type, Connection.IOT_2G)

--- a/tplinkrouterc6u/client.py
+++ b/tplinkrouterc6u/client.py
@@ -575,10 +575,13 @@ class TPLinkDecoClient(TplinkEncryption, AbstractRouter):
                 status.iot_clients_total += 1
 
             ip = item['ip'] if item.get('ip') else '0.0.0.0'
-            devices.append(Device(conn,
+            device = Device(conn,
                                   macaddress.EUI48(item['mac']),
                                   ipaddress.IPv4Address(ip),
-                                  base64.b64decode(item['name']).decode()))
+                                  base64.b64decode(item['name']).decode())
+            device.down_speed = item.get('down_speed')
+            device.up_speed = item.get('up_speed')
+            devices.append(device)
 
         status.clients_total = (status.wired_total + status.wifi_clients_total + status.guest_clients_total
                                 + (0 if status.iot_clients_total is None else status.iot_clients_total))

--- a/tplinkrouterc6u/dataclass.py
+++ b/tplinkrouterc6u/dataclass.py
@@ -21,6 +21,8 @@ class Device:
         self.hostname = hostname
         self.packets_sent: int | None = None
         self.packets_received: int | None = None
+        self.down_speed: int | None = None
+        self.up_speed: int | None = None
 
     @property
     def macaddr(self):


### PR DESCRIPTION
The data was already in the Deco tests so this should be an easy addition. In case we don't have the data in the returned JSON, we are using `.get` which will return None if it doesn't exist so this change should not break anything.

This is in reference to https://github.com/AlexandrErohin/home-assistant-tplink-router/issues/60