### PR TITLE
Added Ability to Change Wireless Settings for Archer C1200 and Fixed Issue with `set_wifi`

### DIFF
--- a/test/test_client_c1200.py
+++ b/test/test_client_c1200.py
@@ -1,0 +1,141 @@
+import unittest
+import json
+from tplinkrouterc6u import (
+    TplinkC1200Router,
+    Connection,
+    ClientException
+)
+
+
+class TestTPLinkC1200Client(unittest.TestCase):
+
+    def test_set_led_on(self) -> None:
+
+        response_led_general_read = '''
+        {
+            "enable": "off",
+            "time_set": "yes",
+            "ledpm_support": "yes"
+        }
+        '''
+
+        response_led_general_write = '''
+        {
+            "enable": "on",
+            "time_set": "yes",
+            "ledpm_support": "yes"
+        }
+        '''
+
+        class TPLinkRouterTest(TplinkC1200Router):
+            def request(self, path: str, data: str,
+                        ignore_response: bool = False, ignore_errors: bool = False) -> dict | None:
+                if path == 'admin/ledgeneral?form=setting&operation=read':
+                    return json.loads(response_led_general_read)
+                if path == 'admin/ledgeneral?form=setting&operation=write':
+                    self.captured_path = path
+                    return json.loads(response_led_general_write)
+                raise ClientException()
+
+        client = TPLinkRouterTest('', '')
+        
+        client.set_led(True)
+
+        expected_path = "admin/ledgeneral?form=setting&operation=write"
+        
+        self.assertEqual(client.captured_path, expected_path)
+
+    def test_set_led_off(self) -> None:
+
+        response_led_general_read = '''
+        {
+            "enable": "on",
+            "time_set": "yes",
+            "ledpm_support": "yes"
+        }
+        '''
+
+        response_led_general_write = '''
+        {
+            "enable": "off",
+            "time_set": "yes",
+            "ledpm_support": "yes"
+        }
+        '''
+
+        class TPLinkRouterTest(TplinkC1200Router):
+            def request(self, path: str, data: str,
+                        ignore_response: bool = False, ignore_errors: bool = False) -> dict | None:
+                if path == 'admin/ledgeneral?form=setting&operation=read':
+                    return json.loads(response_led_general_read)
+                elif path == 'admin/ledgeneral?form=setting&operation=write':
+                    self.captured_path = path
+                    return json.loads(response_led_general_write)
+                raise ClientException()
+
+        client = TPLinkRouterTest('', '')
+
+        client.set_led(False)
+
+        expected_path = "admin/ledgeneral?form=setting&operation=write"
+        
+        self.assertEqual(client.captured_path, expected_path)
+
+    def test_led_status(self) -> None:
+
+        response_led_general_read = '''
+        {
+            "enable": "on",
+            "time_set": "yes",
+            "ledpm_support": "yes"
+        }
+        '''
+        
+        class TPLinkRouterTest(TplinkC1200Router):
+            def request(self, path: str, data: str,
+                        ignore_response: bool = False, ignore_errors: bool = False) -> dict | None:
+                if path == 'admin/ledgeneral?form=setting&operation=read':
+                    return json.loads(response_led_general_read)
+                raise ClientException()
+
+        client = TPLinkRouterTest('', '')
+
+        led_status = client.get_led()
+        self.assertTrue(led_status)
+
+    def test_set_wifi(self) -> None:
+
+        class TPLinkRouterTest(TplinkC1200Router):
+            def request(self, path: str, data: str,
+                        ignore_response: bool = False, ignore_errors: bool = False) -> dict | None:
+
+                self.captured_path = path
+                self.captured_data = data
+
+        client = TPLinkRouterTest('', '')
+        client.set_wifi(
+            Connection.HOST_5G,
+            enable=True,
+            ssid="TestSSID",
+            hidden="no",
+            encryption="WPA3-PSK",
+            psk_version="2",
+            psk_cipher="AES",
+            psk_key="testkey123",
+            hwmode="11ac",
+            htmode="VHT20",
+            channel=36,
+            txpower="20",
+            disabled_all="no"
+        )
+        
+        expected_data = ("operation=write&enable=on&ssid=TestSSID&hidden=no&encryption=WPA3-PSK&"
+                         "psk_version=2&psk_cipher=AES&psk_key=testkey123&hwmode=11ac&"
+                         "htmode=VHT20&channel=36&txpower=20&disabled_all=no")
+        expected_path = f"admin/wireless?form=wireless_5g&{expected_data}"
+        
+        self.assertEqual(client.captured_path, expected_path)
+        self.assertEqual(client.captured_data, expected_data)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tplinkrouterc6u/client.py
+++ b/tplinkrouterc6u/client.py
@@ -11,7 +11,7 @@ import ipaddress
 from logging import Logger
 from tplinkrouterc6u.encryption import EncryptionWrapper, EncryptionWrapperMR
 from tplinkrouterc6u.enum import Connection
-from tplinkrouterc6u.dataclass import Firmware, Ledstatus, Status, Device, IPv4Reservation, IPv4DHCPLease, IPv4Status
+from tplinkrouterc6u.dataclass import Firmware, Status, Device, IPv4Reservation, IPv4DHCPLease, IPv4Status
 from tplinkrouterc6u.exception import ClientException, ClientError
 from abc import ABC, abstractmethod
 

--- a/tplinkrouterc6u/client.py
+++ b/tplinkrouterc6u/client.py
@@ -722,6 +722,58 @@ class TplinkC1200Router(TplinkBaseRouter):
         else:
             return None
 
+    def set_wifi(self, wifi: Connection, enable: bool = None, ssid: str = None, hidden: str = None, encryption: str = None, psk_version: str = None, psk_cipher: str = None, psk_key: str = None, hwmode: str = None, htmode: str = None, channel: int = None, txpower: str = None, disabled_all: str = None) -> None:
+        values = {
+            Connection.HOST_2G: 'wireless_2g',
+            Connection.HOST_5G: 'wireless_5g',
+            Connection.HOST_6G: 'wireless_6g',
+            Connection.GUEST_2G: 'guest_2g',
+            Connection.GUEST_5G: 'guest_5g',
+            Connection.GUEST_6G: 'guest_6g',
+            Connection.IOT_2G: 'iot_2g',
+            Connection.IOT_5G: 'iot_5g',
+            Connection.IOT_6G: 'iot_6g',
+        }
+        
+        value = values.get(wifi)
+        if not value:
+            raise ValueError(f"Invalid Wi-Fi connection type: {wifi}")
+        
+        if enable is None and ssid is None and hidden is None and encryption is None and psk_version is None and psk_cipher is None and psk_key is None and hwmode is None and htmode is None and channel is None and txpower is None and disabled_all is None:
+            raise ValueError("At least one wireless setting must be provided")
+        
+        
+        data = "operation=write"
+        
+        if enable is not None:
+            data += f"&enable={'on' if enable else 'off'}"
+        if ssid is not None:
+            data += f"&ssid={ssid}"
+        if hidden is not None:
+            data += f"&hidden={hidden}"
+        if encryption is not None:
+            data += f"&encryption={encryption}"
+        if psk_version is not None:
+            data += f"&psk_version={psk_version}"
+        if psk_cipher is not None:
+            data += f"&psk_cipher={psk_cipher}"
+        if psk_key is not None:
+            data += f"&psk_key={psk_key}"
+        if hwmode is not None:
+            data += f"&hwmode={hwmode}"
+        if htmode is not None:
+            data += f"&htmode={htmode}"
+        if channel is not None:
+            data += f"&channel={channel}"
+        if txpower is not None:
+            data += f"&txpower={txpower}"
+        if disabled_all is not None:
+            data += f"&disabled_all={disabled_all}"
+        
+        path = f"admin/wireless?form={value}&{data}"
+        
+        self.request(path, data)
+
 class TPLinkMRClient(AbstractRouter):
     REQUEST_RETRIES = 3
 

--- a/tplinkrouterc6u/client.py
+++ b/tplinkrouterc6u/client.py
@@ -695,6 +695,7 @@ class TplinkC1200Router(TplinkBaseRouter):
             regex_result = re.search('sysauth=(.*);', response.headers['set-cookie'])
             self._sysauth = regex_result.group(1)
             self._logged = True
+            self._smart_network = False
 
         except Exception as e:
             error = "TplinkRouter - C1200 - Cannot authorize! Error - {}; Response - {}".format(e, response.text)

--- a/tplinkrouterc6u/dataclass.py
+++ b/tplinkrouterc6u/dataclass.py
@@ -11,6 +11,10 @@ class Firmware:
         self.model = model
         self.firmware_version = firmware
 
+@dataclass
+class Ledstatus:
+    def __init__(self, led_status: str) -> None:
+        self.led: bool | None = None
 
 @dataclass
 class Device:
@@ -21,8 +25,6 @@ class Device:
         self.hostname = hostname
         self.packets_sent: int | None = None
         self.packets_received: int | None = None
-        self.down_speed: int | None = None
-        self.up_speed: int | None = None
 
     @property
     def macaddr(self):
@@ -44,7 +46,6 @@ class Device:
 @dataclass
 class Status:
     def __init__(self) -> None:
-        self.led: bool | None = None
         self._wan_macaddr: macaddress.EUI48 | None = None
         self._lan_macaddr: macaddress
         self._wan_ipv4_addr: ipaddress.IPv4Address | None = None

--- a/tplinkrouterc6u/dataclass.py
+++ b/tplinkrouterc6u/dataclass.py
@@ -25,6 +25,8 @@ class Device:
         self.hostname = hostname
         self.packets_sent: int | None = None
         self.packets_received: int | None = None
+        self.down_speed: int | None = None
+        self.up_speed: int | None = None
 
     @property
     def macaddr(self):

--- a/tplinkrouterc6u/dataclass.py
+++ b/tplinkrouterc6u/dataclass.py
@@ -44,6 +44,7 @@ class Device:
 @dataclass
 class Status:
     def __init__(self) -> None:
+        self.led: bool | None = None
         self._wan_macaddr: macaddress.EUI48 | None = None
         self._lan_macaddr: macaddress
         self._wan_ipv4_addr: ipaddress.IPv4Address | None = None


### PR DESCRIPTION
### Summary
- Added support for changing various wireless settings on the Archer C1200 router.
- Fixed an issue with the Archer C1200 router where `set_wifi` could not toggle the Wi-Fi radios on and off.

### Changes
- Duplicated the `set_wifi` function and placed it under the `TplinkC1200Router` class.
- Added the ability to specify multiple wireless settings; at least one setting must be provided.
- Modified the request path to include data in the URL, which is required by the C1200 router.

### Details
Previously, the `set_wifi` function used the following path:
```python
path = f"admin/wireless?&form=guest&form={value}"
```
The Archer C1200 router requires the path to be in this format:
```python
path = f"admin/wireless?form={value}&{data}"
```
This change ensures that the function works correctly with the C1200 router.

### Usage
Here is an example of how to use the updated `set_wifi` function:
```python
router.set_wifi(
    wifi=Connection.HOST_2G,
    enable=True,
    ssid="SSID",
    hidden="off",
    encryption="psk",
    psk_version="auto",
    psk_cipher="auto",
    psk_key="PASSWORD",
    hwmode="bgn",
    htmode="40",
    channel=1,
    txpower="high",
    disabled_all="off"
)
```
Note: Not all options need to be specified; however, `wifi` is necessary and at least one additional setting must be provided.

### Compatibility
While this code is for the Archer C1200, it should work for other routers with slight modifications. Specifically, the original `set_wifi` function's path includes `form=guest`, which might need to be added for different models.
I did not add this because i can't test it.
