### PR TITLE
fix: handle empty wan_macaddr in data

### DIFF
--- a/test/test_client_c6u.py
+++ b/test/test_client_c6u.py
@@ -741,14 +741,6 @@ class TestTPLinkClient(TestCase):
         }
     }
     '''
-        perf_stats = '''
-      {
-          "data": {"mem_usage":0.47, "cpu_usage":0.25},
-          "timeout": false,
-          "success": true,
-          "operator": "load"
-      }
-    '''
         response_stats = '''
       {
           "data": [],
@@ -763,8 +755,6 @@ class TestTPLinkClient(TestCase):
                         ignore_response: bool = False, ignore_errors: bool = False) -> dict | None:
                 if path == 'admin/status?form=all&operation=read':
                     return loads(response_status)['data']
-                elif path == 'admin/status?form=perf&operation=read':
-                    return loads(perf_stats)['data']
                 elif path == 'admin/wireless?form=statistics':
                     return loads(response_stats)['data']
                 raise ClientException()

--- a/test/test_client_c6u.py
+++ b/test/test_client_c6u.py
@@ -729,6 +729,55 @@ class TestTPLinkClient(TestCase):
         self.assertEqual(result.lan_ipv4_dhcp_enable, False)
         self.assertEqual(result.remote, None)
 
+    def test_get_status_wan_macaddr_empty(self) -> None:
+        response_status = '''
+    {
+        "success": true,
+        "data": {
+            "lan_macaddr": "06:e6:97:9e:23:f5",
+            "wan_macaddr": "",
+            "wan_ipv4_ipaddr": "0.0.0.0",
+            "wan_ipv4_gateway": "0.0.0.0"
+        }
+    }
+    '''
+        perf_stats = '''
+      {
+          "data": {"mem_usage":0.47, "cpu_usage":0.25},
+          "timeout": false,
+          "success": true,
+          "operator": "load"
+      }
+    '''
+        response_stats = '''
+      {
+          "data": [],
+          "timeout": false,
+          "success": true,
+          "operator": "load"
+      }
+    '''
+
+        class TPLinkRouterTest(TplinkRouter):
+            def request(self, path: str, data: str,
+                        ignore_response: bool = False, ignore_errors: bool = False) -> dict | None:
+                if path == 'admin/status?form=all&operation=read':
+                    return loads(response_status)['data']
+                elif path == 'admin/status?form=perf&operation=read':
+                    return loads(perf_stats)['data']
+                elif path == 'admin/wireless?form=statistics':
+                    return loads(response_stats)['data']
+                raise ClientException()
+
+        client = TPLinkRouterTest('', '')
+        result = client.get_status()
+
+        self.assertIsInstance(result, Status)
+        self.assertEqual(result.wan_macaddr, None)
+        self.assertEqual(result.wan_ipv4_addr, '0.0.0.0')
+        self.assertEqual(result.wan_ipv4_gateway, '0.0.0.0')
+        self.assertEqual(result.lan_macaddr, '06-E6-97-9E-23-F5')
+
 
 if __name__ == '__main__':
     main()

--- a/tplinkrouterc6u/client/c6u.py
+++ b/tplinkrouterc6u/client/c6u.py
@@ -275,7 +275,7 @@ class TplinkBaseRouter(AbstractRouter, TplinkRequest):
         data = self.request('admin/status?form=all&operation=read', 'operation=read')
 
         status = Status()
-        status._wan_macaddr = EUI48(data['wan_macaddr']) if 'wan_macaddr' in data else None
+        status._wan_macaddr = EUI48(data['wan_macaddr']) if 'wan_macaddr' in data and data['wan_macaddr'] else None
         status._lan_macaddr = EUI48(data['lan_macaddr'])
         status._wan_ipv4_addr = IPv4Address(data['wan_ipv4_ipaddr']) if 'wan_ipv4_ipaddr' in data else None
         status._lan_ipv4_addr = IPv4Address(data['lan_ipv4_ipaddr']) if 'lan_ipv4_ipaddr' in data else None


### PR DESCRIPTION
Firmware Version: 1.1.2 Build 20250317 rel.18331(4153), Hardware Version: Archer BE550 v1.0, Model: Archer BE550

```
"C:\Users\Dos\Desktop\testpython\main.py", line 23, in <module>
    status = router.get_status()
             ^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Dos\Desktop\testpython\venv\Lib\site-packages\tplinkrouterc6u\client\c6u.py", line 278, in get_status
    status._wan_macaddr = EUI48(data['wan_macaddr']) if 'wan_macaddr' in data else None
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Dos\Desktop\testpython\venv\Lib\site-packages\macaddress.py", line 106, in _init_
    self._address, _ = _parse(address, type(self))
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Dos\Desktop\testpython\venv\Lib\site-packages\macaddress.py", line 362, in _parse
    raise ValueError('hardware address cannot be an empty string')
ValueError: hardware address cannot be an empty string
```

handle empty wan_macaddr in data