### PR TITLE
Added exception handling the ex.py client as some routers return 406 on the Memory request

### DIFF
--- a/tplinkrouterc6u/client/ex.py
+++ b/tplinkrouterc6u/client/ex.py
@@ -150,12 +150,12 @@ class TPLinkEXClient(TPLinkMRClientBase):
             total = int(values[4]['total'])
             free = int(values[4]["free"])
             status.mem_usage = ((total - free) / total)
-        except ValueError:
+        except Exception:
             status.mem_usage = 0
 
         try:
             status.cpu_usage =int(values[5]['CPUUsage']) / 100
-        except ValueError:
+        except Exception:
             status.cpu_usage = 0
 
         status.devices = list(devices.values())

--- a/tplinkrouterc6u/client/mr.py
+++ b/tplinkrouterc6u/client/mr.py
@@ -553,9 +553,10 @@ class TPLinkMRClientBase(AbstractRouter):
             if r.status_code != 500 and '<title>500 Internal Server Error</title>' not in r.text:
                 break
 
-            sleep(0.05)
             retry += 1
+            sleep(0.1*retry)
 
+        sleep(0.05)
         # decrypt the response, if needed
         if encrypt and (r.status_code == 200) and (r.text != ''):
             return r.status_code, self._encryption.aes_decrypt(r.text)


### PR DESCRIPTION
As described in https://github.com/AlexandrErohin/home-assistant-tplink-router/issues/180 sometimes certain routers return 406  for the memory state request.
This is one way to handle those 406 responses feel free to give me feedback on this draft. 
Do you want to handle it in another way ?
