### PR TITLE
Change to properly enable LTE sensors

### DIFF
--- a/tplinkrouterc6u/client/mr.py
+++ b/tplinkrouterc6u/client/mr.py
@@ -18,7 +18,6 @@ from tplinkrouterc6u.common.dataclass import (
     IPv4DHCPLease,
     IPv4Status,
     SMS,
-    LTEStatus,
     VPNStatus,
 )
 from tplinkrouterc6u.common.exception import ClientException, ClientError

--- a/tplinkrouterc6u/client_abstract.py
+++ b/tplinkrouterc6u/client_abstract.py
@@ -1,7 +1,7 @@
 from requests.packages import urllib3
 from logging import Logger
 from tplinkrouterc6u.common.package_enum import Connection
-from tplinkrouterc6u.common.dataclass import Firmware, Status, IPv4Status, LTEStatus
+from tplinkrouterc6u.common.dataclass import Firmware, Status, IPv4Status
 from abc import ABC, abstractmethod
 
 


### PR DESCRIPTION
In this PR I am proposing a change to this lib that consists in reorganizing the data classes related to Status. For that effect I have defined a top level Status class which parents the RouterStatus (which contains the same attributes as the former Status class) along with IPv4Status, LTEStatus, and VPNStatus. 

In the mr.py module get_status() will now call populate_lte_status() in order to populate the state attributes that are specific to the LTE enabled devices.

I will also open a PR on the hassio integration project (https://github.com/AlexandrErohin/home-assistant-tplink-router) that will require these changes.