### PR TITLE
Draft for modifcations to support new firmware on VX2310V

### DIFF
--- a/tplinkrouterc6u/client/ex.py
+++ b/tplinkrouterc6u/client/ex.py
@@ -277,10 +277,10 @@ class TPLinkEXClient(TPLinkMRClientBase):
             b64encode(bytes(self.password, "utf-8")).decode("utf-8")
         )
 
-        sign, data = self._prepare_data(login_data, True)
+        sign, data, tag = self._prepare_data(login_data, True)
         assert len(sign) == 256
 
-        request_data = f"sign={sign}\r\ndata={data}\r\n"
+        request_data = f"sign={sign}\r\ndata={data}\r\ntag={tag}\r\n"
 
         url = f"{self.host}/cgi_gdpr?9"
         (code, response) = self._request(url, data_str=request_data)

--- a/tplinkrouterc6u/client/mr.py
+++ b/tplinkrouterc6u/client/mr.py
@@ -534,8 +534,8 @@ class TPLinkMRClientBase(AbstractRouter):
 
         # encrypt request data if needed (for the /cgi_gdpr endpoint)
         if encrypt:
-            sign, data = self._prepare_data(data_str, is_login)
-            data = 'sign={}\r\ndata={}\r\n'.format(sign, data)
+            sign, data ,tag = self._prepare_data(data_str, is_login)
+            data = 'sign={}\r\ndata={}\r\ntag={}\r\n'.format(sign, data, tag)
         else:
             data = data_str
 
@@ -578,13 +578,13 @@ class TPLinkMRClientBase(AbstractRouter):
         return int(result.group(1))
 
     def _prepare_data(self, data: str, is_login: bool) -> tuple[str, str]:
-        encrypted_data = self._encryption.aes_encrypt(data)
+        encrypted_data, tag = self._encryption.aes_encrypt(data)
         data_len = len(encrypted_data)
         # get encrypted signature
         signature = self._encryption.get_signature(int(self._seq) + data_len, is_login, self._hash, self._nn, self._ee)
 
         # format expected raw request data
-        return signature, encrypted_data
+        return signature, encrypted_data, tag
 
 
 class TPLinkMRClient(TPLinkMRClientBase):


### PR DESCRIPTION
to test this you can get the firmware with 
```
from ex import TPLinkEXClient
import logging

logger = logging.getLogger("tplink_ex")
client = TPLinkEXClient('ip', 'password', username = 'user', logger=logger,)
client.authorize()
status=client.get_firmware()
print(status)
```
output looks like this 
`Firmware(hardware_version='VX231v v1.0 00000000', model='VX231v', firmware_version='231.0.19')`

new Encryption mode is gcm and requires a tag in addition to the encrypted text see:
https://master-spring-ter.medium.com/aes-cbc-vs-gcm-in-spring-boot-which-mode-should-you-choose-1adb3de475ac

also i think key and iv are now in base 64 