### PR TITLE
Add vx220 client

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ or you have TP-link C5400X or similar router you need to get web encrypted passw
 - Archer VR600 v3
 - Archer VR900v
 - Archer VX1800v v1.0
+- Archer VX220-G2v v2.0
 - Archer VX231v v1.0
 - BE11000 2.0
 - CPE210 v2.0

--- a/test/test_client_vx220.py
+++ b/test/test_client_vx220.py
@@ -1,0 +1,161 @@
+from unittest import main, TestCase
+from macaddress import EUI48
+from ipaddress import IPv4Address
+from tplinkrouterc6u import (
+    TPLinkVX220Client,
+    Connection,
+    Firmware,
+    Status,
+    Device,
+    ClientException,
+)
+
+
+class TestTPLinkVX220Client(TestCase):
+    def test_supports(self) -> None:
+        homepage = '<html><title>VX220-G2v</title><script src="cgi/getGDPRParm"></script></html>'
+
+        class TPLinkVX220ClientTest(TPLinkVX220Client):
+            def _request(self, url, method='POST', data_str=None, encrypt=False):
+                if method == 'GET':
+                    return 200, homepage
+                raise ClientException()
+
+        client = TPLinkVX220ClientTest('', '')
+        result = client._verify_router()
+
+        self.assertTrue(result)
+
+    def test_supports_fail(self) -> None:
+        homepage = '<html><title>Archer C6U</title><script src="cgi/getGDPRParm"></script></html>'
+
+        class TPLinkVX220ClientTest(TPLinkVX220Client):
+            def _request(self, url, method='POST', data_str=None, encrypt=False):
+                if method == 'GET':
+                    return 200, homepage
+                raise ClientException()
+
+        client = TPLinkVX220ClientTest('', '')
+        result = client._verify_router()
+
+        self.assertFalse(result)
+
+    def test_firmware(self) -> None:
+        response = ('{"data":{"hardwareVersion":"VX220-G2v v2.0 00000000","modelName":"VX220-G2v",'
+                    '"softwareVersion":"0.9.0 2.0.0 v603c.0 Build 250328 Rel.7572n","stack":"0,0,0,0,0,0"},'
+                    '"operation":"go","oid":"DEV2_DEV_INFO","success":true}')
+
+        class TPLinkVX220ClientTest(TPLinkVX220Client):
+            self._token = True
+
+            def _request(self, url, method='POST', data_str=None, encrypt=False):
+                return 200, response
+
+        client = TPLinkVX220ClientTest('', '')
+        result = client.get_firmware()
+
+        self.assertIsInstance(result, Firmware)
+        self.assertEqual(result.hardware_version, 'VX220-G2v v2.0 00000000')
+        self.assertEqual(result.model, 'VX220-G2v')
+        self.assertEqual(result.firmware_version, '0.9.0 2.0.0 v603c.0 Build 250328 Rel.7572n')
+
+    def test_get_status(self) -> None:
+
+        DEV2_ADT_LAN = ('{"data":[{"MACAddress":"b4:b0:24:aa:bb:cc","IPAddress":"192.168.1.1","stack":"1,0,0,0,0,0"}],'
+                        '"operation":"gl","oid":"DEV2_ADT_LAN","success":true}')
+        DEV2_ADT_WAN = ('{"data":[{"enable":"1","MACAddr":"C8-3A-35-DD-EE-FF","connIPv4Address":"100.64.1.10",'
+                        '"connIPv4Gateway":"100.64.1.1","stack":"1,0,0,0,0,0"}],"operation":"gl",'
+                        '"oid":"DEV2_ADT_WAN","success":true}')
+        DEV2_ADT_WIFI_COMMON = ('{"data":[{"primaryEnable":"1","guestEnable":"0","stack":"1,0,0,0,0,0"},'
+                                '{"primaryEnable":"1","guestEnable":"0","stack":"2,0,0,0,0,0"}],"operation":"gl",'
+                                '"oid":"DEV2_ADT_WIFI_COMMON","success":true}')
+        DEV2_HOST_ENTRY = ('{"data":[{"active":"1","X_TP_LanConnType":"0","physAddress":"AA-BB-CC-11-22-33",'
+                           '"IPAddress":"192.168.1.100","hostName":"desktop","stack":"1,0,0,0,0,0"},'
+                           '{"active":"1","X_TP_LanConnType":"1","physAddress":"DD-EE-FF-44-55-66",'
+                           '"IPAddress":"192.168.1.101","hostName":"phone","stack":"2,0,0,0,0,0"},'
+                           '{"active":"1","X_TP_LanConnType":"3","physAddress":"77-88-99-AA-BB-CC",'
+                           '"IPAddress":"192.168.1.102","hostName":"laptop","stack":"3,0,0,0,0,0"}],"operation":"gl",'
+                           '"oid":"DEV2_HOST_ENTRY","success":true}')
+        DEV2_MEM_STATUS = ('{"data":{"total":"256000","free":"128000","stack":"0,0,0,0,0,0"},"operation":"go",'
+                           '"oid":"DEV2_MEM_STATUS","success":true}')
+        DEV2_PROC_STATUS = ('{"data":{"CPUUsage":"35","stack":"0,0,0,0,0,0"},"operation":"go",'
+                            '"oid":"DEV2_PROC_STATUS","success":true}')
+
+        class TPLinkVX220ClientTest(TPLinkVX220Client):
+            self._token = True
+
+            def _request(self, url, method='POST', data_str=None, encrypt=False):
+                if 'DEV2_ADT_LAN' in data_str:
+                    return 200, DEV2_ADT_LAN
+                elif 'DEV2_ADT_WAN' in data_str:
+                    return 200, DEV2_ADT_WAN
+                elif 'DEV2_ADT_WIFI_COMMON' in data_str:
+                    return 200, DEV2_ADT_WIFI_COMMON
+                elif 'DEV2_HOST_ENTRY' in data_str:
+                    return 200, DEV2_HOST_ENTRY
+                elif 'DEV2_MEM_STATUS' in data_str:
+                    return 200, DEV2_MEM_STATUS
+                elif 'DEV2_PROC_STATUS' in data_str:
+                    return 200, DEV2_PROC_STATUS
+                raise ClientException()
+
+        client = TPLinkVX220ClientTest('', '')
+        status = client.get_status()
+
+        self.assertIsInstance(status, Status)
+        self.assertEqual(status.wan_macaddr, 'C8-3A-35-DD-EE-FF')
+        self.assertIsInstance(status.wan_macaddress, EUI48)
+        self.assertEqual(status.lan_macaddr, 'B4-B0-24-AA-BB-CC')
+        self.assertIsInstance(status.lan_macaddress, EUI48)
+        self.assertEqual(status.wan_ipv4_addr, '100.64.1.10')
+        self.assertIsInstance(status.wan_ipv4_address, IPv4Address)
+        self.assertEqual(status.lan_ipv4_addr, '192.168.1.1')
+        self.assertIsInstance(status.lan_ipv4_address, IPv4Address)
+        self.assertEqual(status.wan_ipv4_gateway, '100.64.1.1')
+        self.assertEqual(status.wired_total, 1)
+        self.assertEqual(status.wifi_clients_total, 2)
+        self.assertEqual(status.guest_clients_total, 0)
+        self.assertEqual(status.clients_total, 3)
+        self.assertEqual(status.guest_2g_enable, False)
+        self.assertEqual(status.guest_5g_enable, False)
+        self.assertEqual(status.iot_2g_enable, None)
+        self.assertEqual(status.iot_5g_enable, None)
+        self.assertEqual(status.wifi_2g_enable, True)
+        self.assertEqual(status.wifi_5g_enable, True)
+        self.assertEqual(status.wan_ipv4_uptime, None)
+        self.assertGreaterEqual(status.mem_usage, 0)
+        self.assertLessEqual(status.mem_usage, 1)
+        self.assertGreaterEqual(status.cpu_usage, 0)
+        self.assertLessEqual(status.cpu_usage, 1)
+        self.assertEqual(len(status.devices), 3)
+        self.assertIsInstance(status.devices[0], Device)
+        self.assertEqual(status.devices[0].type, Connection.WIRED)
+        self.assertEqual(status.devices[0].macaddr, 'AA-BB-CC-11-22-33')
+        self.assertIsInstance(status.devices[0].macaddress, EUI48)
+        self.assertEqual(status.devices[0].ipaddr, '192.168.1.100')
+        self.assertIsInstance(status.devices[0].ipaddress, IPv4Address)
+        self.assertEqual(status.devices[0].hostname, 'desktop')
+        self.assertEqual(status.devices[0].packets_sent, None)
+        self.assertEqual(status.devices[0].packets_received, None)
+        self.assertIsInstance(status.devices[1], Device)
+        self.assertEqual(status.devices[1].type, Connection.HOST_2G)
+        self.assertEqual(status.devices[1].macaddr, 'DD-EE-FF-44-55-66')
+        self.assertIsInstance(status.devices[1].macaddress, EUI48)
+        self.assertEqual(status.devices[1].ipaddr, '192.168.1.101')
+        self.assertIsInstance(status.devices[1].ipaddress, IPv4Address)
+        self.assertEqual(status.devices[1].hostname, 'phone')
+        self.assertEqual(status.devices[1].packets_sent, None)
+        self.assertEqual(status.devices[1].packets_received, None)
+        self.assertIsInstance(status.devices[2], Device)
+        self.assertEqual(status.devices[2].type, Connection.HOST_5G)
+        self.assertEqual(status.devices[2].macaddr, '77-88-99-AA-BB-CC')
+        self.assertIsInstance(status.devices[2].macaddress, EUI48)
+        self.assertEqual(status.devices[2].ipaddr, '192.168.1.102')
+        self.assertIsInstance(status.devices[2].ipaddress, IPv4Address)
+        self.assertEqual(status.devices[2].hostname, 'laptop')
+        self.assertEqual(status.devices[2].packets_sent, None)
+        self.assertEqual(status.devices[2].packets_received, None)
+
+
+if __name__ == '__main__':
+    main()

--- a/tplinkrouterc6u/__init__.py
+++ b/tplinkrouterc6u/__init__.py
@@ -7,6 +7,7 @@ from tplinkrouterc6u.client.mr200 import TPLinkMR200Client
 from tplinkrouterc6u.client.mr6400v7 import TPLinkMR6400v7Client
 from tplinkrouterc6u.client.ex import TPLinkEXClient, TPLinkEXClientGCM
 from tplinkrouterc6u.client.vr import TPLinkVRClient
+from tplinkrouterc6u.client.vx220 import TPLinkVX220Client
 from tplinkrouterc6u.client.vr400v2 import TPLinkVR400v2Client
 from tplinkrouterc6u.client.c80 import TplinkC80Router
 from tplinkrouterc6u.client.c5400x import TplinkC5400XRouter

--- a/tplinkrouterc6u/client/vx220.py
+++ b/tplinkrouterc6u/client/vx220.py
@@ -1,0 +1,78 @@
+from base64 import b64encode
+from http import HTTPStatus
+from logging import Logger
+from tplinkrouterc6u.client.ex import TPLinkEXClientGCM
+from tplinkrouterc6u.common.encryption import EncryptionWrapperMRGCMOAEP
+from tplinkrouterc6u.common.exception import ClientException
+
+
+class TPLinkVX220Client(TPLinkEXClientGCM):
+    def __init__(self, host: str, password: str, username: str = 'admin', logger: Logger = None,
+                 verify_ssl: bool = True, timeout: int = 30):
+        super().__init__(host, password, username, logger, verify_ssl, timeout)
+        self._encryption = EncryptionWrapperMRGCMOAEP()
+
+    def supports(self):
+        return self._verify_router() and super().supports()
+
+    def _req_login(self) -> None:
+        login_data = ('{"data":{"UserName":"%s","Passwd":"%s","Action": "1","stack":"0,0,0,0,0,0",'
+                      '"pstack":"0,0,0,0,0,0"},"operation":"cgi","oid":"/cgi/login"}') % (
+            b64encode(bytes(self.username, "utf-8")).decode("utf-8"),
+            b64encode(bytes(self.password, "utf-8")).decode("utf-8")
+        )
+
+        sign, data, tag = self._prepare_data(login_data, True)
+
+        request_data = f"sign={sign}\r\ndata={data}\r\ntag={tag}\r\n"
+
+        url = f"{self.host}/cgi_gdpr?9"
+        (code, response) = self._request(url, data_str=request_data)
+        response = self._encryption.aes_decrypt(response)
+
+        ret_code = self._parse_ret_val(response)
+        error = ''
+        if ret_code == self.HTTP_ERR_USER_PWD_NOT_CORRECT:
+            error = ('TplinkRouter - EX - Login failed, wrong user or password. '
+                     'Try to pass user instead of admin in username')
+        elif ret_code == self.HTTP_ERR_USER_BAD_REQUEST:
+            error = 'TplinkRouter - EX - Login failed. Generic error code: {}'.format(ret_code)
+        elif ret_code != self.HTTP_RET_OK:
+            error = 'TplinkRouter - EX - Login failed. Unknown error code: {}'.format(ret_code)
+
+        if error:
+            if self._logger:
+                self._logger.debug(error)
+            raise ClientException(error)
+
+    def _verify_router(self) -> bool:
+        is_VX220 = False
+        has_url_rsa_endpoint = False
+
+        try:
+            status_code, response = self._request(self.host, method='GET')
+        except Exception as e:
+            if self._logger is not None:
+                self._logger.error("Error while checking modem: {}".format(e))
+            return False
+
+        if status_code == HTTPStatus.OK:
+            is_VX220 = "VX220" in response
+            has_url_rsa_endpoint = self._url_rsa_key in response
+
+        if has_url_rsa_endpoint and is_VX220:
+            return True
+        elif is_VX220:
+            try:
+                status_code, response = self._request("{}/js/lib.js".format(self.host), method='GET')
+            except Exception as e:
+                if self._logger is not None:
+                    self._logger.error("Error while checking if lib.js is present in modem: {}".format(e))
+                return False
+
+            if status_code == HTTPStatus.OK:
+                has_url_rsa_endpoint = (self._url_rsa_key in response)
+
+            return is_VX220 and has_url_rsa_endpoint
+        else:
+            return False

--- a/tplinkrouterc6u/provider.py
+++ b/tplinkrouterc6u/provider.py
@@ -15,6 +15,7 @@ from tplinkrouterc6u.client.c3200 import TplinkC3200Router
 from tplinkrouterc6u.client.c1200 import TplinkC1200Router
 from tplinkrouterc6u.client.c80 import TplinkC80Router
 from tplinkrouterc6u.client.vr import TPLinkVRClient
+from tplinkrouterc6u.client.vx220 import TPLinkVX220Client
 from tplinkrouterc6u.client.vr400v2 import TPLinkVR400v2Client
 from tplinkrouterc6u.client.r import TPLinkRClient
 from tplinkrouterc6u.client.wdr import TplinkWDRRouter
@@ -31,6 +32,7 @@ class TplinkRouterProvider:
         for client in [
                        TplinkC5400XRouter,
                        TPLinkVRClient,
+                       TPLinkVX220Client,
                        TPLinkEXClientGCM,
                        TPLinkEXClient,
                        TPLinkMRClientGCM,


### PR DESCRIPTION
The VX220-G2v uses the EX-style JSON protocol with AES-GCM encryption but differs from other EX GCM routers in two ways: it requires RSA OAEP padding for signatures and its responses use base64(ciphertext + tag) rather than base64(ciphertext) + base64(tag).

- Add TPLinkVX220Client subclassing TPLinkEXClientGCM with homepage detection for "VX220", login override removing the signature length assertion, and router verification via cgi/getGDPRParm endpoint
- Add EncryptionWrapperMRGCMOAEP extending EncryptionWrapperMRGCM with RSA OAEP (SHA-1) signatures and byte-level GCM tag extraction
- Register VX220 client in provider and exports

Tested on:
Firmware Version:0.9.0 2.0.0 v603c.0 Build 250328 Rel.7572n 
Hardware Version:VX220-G2v

My proxmox host has raw bytes in its hostname, unicode decoding so fell back to latin-1.  
