### PR TITLE
Add LTE/5G support for Deco X50-5G

### DIFF
--- a/tplinkrouterc6u/common/dataclass.py
+++ b/tplinkrouterc6u/common/dataclass.py
@@ -286,7 +286,8 @@ class LTEStatus:
         4: "TD-SCDMA",
         5: "CDMA 1x",
         6: "CDMA 1x Ev-Do",
-        7: "4G+ LTE"
+        7: "4G+ LTE",
+        8: "5G NR"
     }
     sim_statuses = {
         0: "No SIM card detected or SIM card error.",


### PR DESCRIPTION
## Summary

- Add `get_lte_status()` to `TPLinkDecoClient` — parses cellular data from `admin/network?form=internet` (`mobile_cpe` object) and maps Deco's string-based fields to `LTEStatus` numeric fields
- Fix WAN IP/gateway/DNS for cellular models by falling back from `wan.ip_info` to `wan.mobile_cpe` in `get_status()` and `get_ipv4_status()`
- Set `conn_type` from `wan.dial_type` in `get_status()`
- Add `"5G NR"` (type 8) to `LTEStatus.network_types`

## Context

The Deco X50-5G is a 5G cellular router. Its API returns WAN info under `wan.mobile_cpe` (not `wan.ip_info`) and `dial_type = "lte"`, which caused `get_status()` to return `None` for WAN IP and connection type. Cellular signal data is available at `admin/network?form=internet` under the `mobile_cpe` key.

The HA integration (`home-assistant-tplink-router`) already gates LTE sensor creation on `hasattr(client, "get_lte_status")`, so no integration changes are needed — adding the method to the Deco client is sufficient.

## Field Mapping

| Deco API (`mobile_cpe`) | `LTEStatus` field | Transform |
|---|---|---|
| `dial_status` | `enable`, `connect_status` | `"connected"` → 1, else 0 |
| `network_type` | `network_type` | string → int (`lte`→3, `lte_plus`→7, `5g_nr`→8, etc.) |
| `sim_status` | `sim_status` | string → int (`ready`→3, `locked`→4, `absent`→1, `error`→2) |
| `data_usage` | `total_statistics` | direct (bytes) |
| `downlink_rate` / `uplink_rate` | `cur_rx_speed` / `cur_tx_speed` | direct |
| `signal_strength` | `sig_level` | ÷25, rounded (0–4 scale) |
| `rsrp`, `rsrq` | `rsrp`, `rsrq` | direct (dBm) |
| `snr` | `snr` | ×10 (HA divides by 10 for display) |
| `profile_name` | `isp_name` | base64 decode |

## Test plan

- [x] 5 new unit tests added (220 total, all passing)
  - `test_get_lte_status` — connected LTE+ with all fields
  - `test_get_lte_status_disconnected` — no SIM / disconnected
  - `test_get_lte_status_5g_nr` — 5G NR network type
  - `test_get_status_cellular` — WAN IP fallback via `mobile_cpe`
  - `test_get_ipv4_status_cellular` — IPv4 status fallback via `mobile_cpe`
- [x] All 220 existing + new tests pass
- [ ] Live-tested on Deco X50-5G (firmware 1.1.1 Build 20250922, Hardware 2.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)