### PR TITLE
Handle empty response data without crashing

### DIFF
--- a/test/test_client_c6u.py
+++ b/test/test_client_c6u.py
@@ -1321,6 +1321,20 @@ class TestTPLinkClient(TestCase):
         with self.assertRaises(ClientException):
             client.get_vpn_client_status()
 
+    def test_decrypt_response_empty_data_returns_empty_dict(self) -> None:
+        """Some firmwares (e.g. newer Deco) return {'data': ''} for endpoints they
+        do not implement. _decrypt_response must not raise on those — return {} so the
+        caller falls through to its standard 'invalid response' handling instead of
+        bubbling up an opaque ord()/JSON error."""
+        from tplinkrouterc6u.client.c6u import TplinkEncryption
+
+        class _Stub(TplinkEncryption):
+            def __init__(self):
+                pass
+
+        self.assertEqual(_Stub()._decrypt_response({'data': ''}), {})
+        self.assertEqual(_Stub()._decrypt_response({}), {})
+
 
 if __name__ == '__main__':
     main()

--- a/test/test_common_encryption.py
+++ b/test/test_common_encryption.py
@@ -1,0 +1,22 @@
+from unittest import main, TestCase
+
+from tplinkrouterc6u.common.encryption import EncryptionWrapper
+
+
+class TestEncryptionWrapper(TestCase):
+    def test_unpad_empty_string_returns_empty(self) -> None:
+        """Empty input must not raise (older code called ord('') and crashed)."""
+        self.assertEqual(EncryptionWrapper._unpad(''), '')
+
+    def test_unpad_empty_bytes_returns_empty(self) -> None:
+        self.assertEqual(EncryptionWrapper._unpad(b''), b'')
+
+    def test_unpad_round_trip(self) -> None:
+        wrapper = EncryptionWrapper()
+        plaintext = 'hello world'
+        ciphertext = wrapper.aes_encrypt(plaintext)
+        self.assertEqual(wrapper.aes_decrypt(ciphertext), plaintext)
+
+
+if __name__ == '__main__':
+    main()

--- a/tplinkrouterc6u/client/c6u.py
+++ b/tplinkrouterc6u/client/c6u.py
@@ -227,6 +227,8 @@ class TplinkEncryption(TplinkRequest):
         return {'sign': sign, 'data': encrypted_data}
 
     def _decrypt_response(self, data: dict) -> dict:
+        if not data.get('data'):
+            return {}
         return loads(self._encryption.aes_decrypt(data['data']))
 
 

--- a/tplinkrouterc6u/common/encryption.py
+++ b/tplinkrouterc6u/common/encryption.py
@@ -59,6 +59,8 @@ class EncryptionWrapper:
 
     @staticmethod
     def _unpad(s):
+        if not s:
+            return s
         return s[:-ord(s[len(s) - 1:])]
 
     def _get_aes_string(self) -> str:


### PR DESCRIPTION
## Problem

Some TP-Link firmwares — notably newer Deco builds — respond to certain admin endpoints (e.g. `admin/wireless?form=wlan`) with `{"data": ""}` instead of an encrypted payload. Today that fails in two unhelpful steps:

1. `EncryptionWrapper._unpad` raises:
   ```
   TypeError: ord() expected a character, but string of length 0 found
   ```
   because `s[len(s) - 1:]` is `''` on empty input.
2. `TplinkEncryption._decrypt_response` then surfaces that as an opaque `ClientError`, which kills the entire status update for callers. The visible victim is the Home Assistant `tplink_router` integration — every poll throws and no router data updates.

Reproduces reliably on a TP-Link Deco mesh on recent firmware: the wireless config endpoint responds with empty data while the rest of the endpoints work fine.

## Fix

- `EncryptionWrapper._unpad` returns the empty value untouched. No-op for any non-empty input — same code path as before.
- `TplinkEncryption._decrypt_response` returns `{}` when `data['data']` is empty or missing, letting the caller fall through to its standard "invalid response" handling instead of bubbling up the underlying decode error.

Net effect: status calls succeed for all endpoints that *do* return data; affected sensors (e.g. `wifi_*_enable` for Decos that don't implement the wireless endpoint) report unknown instead of crashing the whole update.

## Tests

Adds:
- `test/test_common_encryption.py` — empty-string and empty-bytes `_unpad` inputs, plus an AES round-trip sanity check.
- `test/test_client_c6u.py::test_decrypt_response_empty_data_returns_empty_dict` — empty `{'data': ''}` and missing-key cases.

Full suite passes locally (292 tests).