### PR TITLE
fix: get signal level and more lte/5g info for some mobile routers (nx200)

### DIFF
--- a/tplinkrouterc6u/client/ex.py
+++ b/tplinkrouterc6u/client/ex.py
@@ -247,6 +247,8 @@ class TPLinkEXClient(TPLinkMRClientBase):
             self.ActItem(self.ActItem.GET, 'DEV2_LTE_NET_STATUS', '1,0,0,0,0,0',
                          attrs=['smsUnreadCount', 'sigLevel', 'rfInfoRsrp', 'rfInfoRsrq', 'rfInfoSnr']),
             self.ActItem(self.ActItem.GET, 'DEV2_LTE_PROF_STAT', '1,0,0,0,0,0', attrs=['ispName']),
+            self.ActItem(self.ActItem.GL, 'DEV2_LTE_SERVING_CELL_INFO', '0,0,0,0,0,0',
+                         attrs=['networkType', 'signalStrength', 'SSRSRP', 'SSRSRQ', 'SSSINR']),
         ]
         _, values = self.req_act(acts)
 
@@ -260,12 +262,31 @@ class TPLinkEXClient(TPLinkMRClientBase):
         status.cur_tx_speed = int(values[1]['curTxSpeed'])
 
         status.sms_unread_count = int(values[2]['smsUnreadCount'])
-        status.sig_level = int(values[2]['sigLevel'])
-        status.rsrp = int(values[2]['rfInfoRsrp'])
-        status.rsrq = int(values[2]['rfInfoRsrq'])
-        status.snr = int(values[2]['rfInfoSnr'])
 
         status.isp_name = values[3]['ispName']
+
+        lte_net_status = values[2]
+        serving_cell_info_list = values[4]
+
+        # Each entry in serving_cell_info_list is one RAT. Match on active networkType.
+        active_serving_cell = next(
+            (c for c in serving_cell_info_list
+             if int(c.get('networkType', -1)) == status.network_type),
+            None,
+        )
+
+        if active_serving_cell is not None:
+            # Per-RAT signal from DEV2_LTE_SERVING_CELL_INFO
+            status.sig_level = int(active_serving_cell['signalStrength'])
+            status.rsrp = int(active_serving_cell['SSRSRP'])
+            status.rsrq = int(active_serving_cell['SSRSRQ'])
+            status.snr  = int(active_serving_cell['SSSINR'])
+        else:
+            # Fallback: aggregate RF from DEV2_LTE_NET_STATUS (different field names)
+            status.sig_level = int(lte_net_status['sigLevel'])
+            status.rsrp = int(lte_net_status['rfInfoRsrp'])
+            status.rsrq = int(lte_net_status['rfInfoRsrq'])
+            status.snr  = int(lte_net_status['rfInfoSnr'])
 
         return status
 


### PR DESCRIPTION
Hello, for my Archer NX200 (v2.0, running firmware 1.3.0) the LTE/5g signal level and other indicators like rsrp, rsrq and snr were 0.

i saw that this was mentioned for another router (NE200) as issues for the ha integration:
https://github.com/AlexandrErohin/home-assistant-tplink-router/issues/336
https://github.com/AlexandrErohin/home-assistant-tplink-router/issues/318
i suppose my changes should fix it for this router as well.

the information about the signal level is behind another query (DEV2_LTE_SERVING_CELL_INFO), split up for different access technologies (5G, LTE, 3G, etc.)

i adjusted the code in a way that keeps the way it was before (extraction from DEV2_LTE_NET_STATUS) as a fallback. i'm not exactly sure if this is the correct way to do it, or maybe there should be a new subclass for 5g routers. can you give me some guidance on this @AlexandrErohin?

happy to adjust as needed