### PR TITLE
add sms sending capabilities for nx200

### DIFF
--- a/tplinkrouterc6u/client/ex.py
+++ b/tplinkrouterc6u/client/ex.py
@@ -269,6 +269,17 @@ class TPLinkEXClient(TPLinkMRClientBase):
 
         return status
 
+    def send_sms(self, phone_number: str, message: str) -> None:
+        acts = [
+            self.ActItem(
+                self.ActItem.SET, 'DEV2_LTE_SMS_SENDNEWMSG', attrs=[
+                    '"index":"1"',
+                    f'"to":"{phone_number}"',
+                    f'"textContent":"{message}"',
+                ]),
+        ]
+        self.req_act(acts)
+
     def req_act(self, acts: list):
         '''
         Requests ACTs via the cgi_gdpr proxy


### PR DESCRIPTION
hello,

i added sms sending capabilities for the nx200 router. it should probably work for some other models too.

it should fix this issue:
https://github.com/AlexandrErohin/home-assistant-tplink-router/issues/201

i just submitted another pr (#161) where i asked whether it should live in the ex.py file or we should make a subclass for these 5g routers. i was wondering about the same question for this pr.

thanks for maintaining this project, it's great!