### PR TITLE
add sms retrieving capabilities for nx200

### DIFF
--- a/test/test_client_ex.py
+++ b/test/test_client_ex.py
@@ -1,4 +1,5 @@
 from unittest import main, TestCase
+from datetime import datetime
 from macaddress import EUI48
 from ipaddress import IPv4Address
 from tplinkrouterc6u import (
@@ -14,6 +15,7 @@ from tplinkrouterc6u import (
     ClientException,
     VPNStatus,
     VPN,
+    SMS,
 )
 
 
@@ -898,6 +900,132 @@ class TestTPLinkEXClient(TestCase):
         self.assertEqual(check_data, ('{"data":{"stack":"0,0,0,0,0,0","pstack":"0,0,0,0,0,0","index":"1", '
                                       '"to":"534324724234", "textContent":"test sms"},"operation":"so",'
                                       '"oid":"DEV2_LTE_SMS_SENDNEWMSG"}'))
+
+    def test_get_sms(self) -> None:
+        DEV2_LTE_SMS_RECVMSGBOX = ('{"data":{"totalNumber":"2","unreadNumber":"0","pageNumber":"0",'
+                                   '"amountPerPage":"0","stack":"0,0,0,0,0,0"},"operation":"go",'
+                                   '"oid":"DEV2_LTE_SMS_RECVMSGBOX","success":true}')
+        DEV2_LTE_SMS_RECVMSGENTRY = ('{"data":[{"index":"2","from":"sender2","content":"text first",'
+                                     '"receivedTime":"2024-11-15 22:23:59","unread":"0",'
+                                     '"stack":"2,0,0,0,0,0"},{"index":"1","from":"sender1",'
+                                     '"content":"text second","receivedTime":"2024-11-15 22:28:09",'
+                                     '"unread":"1","stack":"1,0,0,0,0,0"}],'
+                                     '"operation":"gl","oid":"DEV2_LTE_SMS_RECVMSGENTRY","success":true}')
+
+        class TPLinkEXClientTest(TPLinkEXClient):
+            def _request(self, url, method='POST', data_str=None, encrypt=False):
+                if 'DEV2_LTE_SMS_RECVMSGBOX' in data_str and '"operation":"go"' in data_str:
+                    return 200, DEV2_LTE_SMS_RECVMSGBOX
+                elif 'DEV2_LTE_SMS_RECVMSGBOX' in data_str:
+                    return 200, '{}'
+                elif 'DEV2_LTE_SMS_RECVMSGENTRY' in data_str:
+                    return 200, DEV2_LTE_SMS_RECVMSGENTRY
+                raise ClientException()
+
+        client = TPLinkEXClientTest('', '')
+        messages = client.get_sms()
+
+        self.assertEqual(len(messages), 2)
+        self.assertIsInstance(messages[0], SMS)
+        self.assertEqual(messages[0].id, 2)
+        self.assertEqual(messages[0].sender, 'sender2')
+        self.assertEqual(messages[0].content, 'text first')
+        self.assertEqual(messages[0].received_at, datetime.fromisoformat('2024-11-15 22:23:59'))
+        self.assertEqual(messages[0].unread, False)
+        self.assertIsInstance(messages[1], SMS)
+        self.assertEqual(messages[1].id, 1)
+        self.assertEqual(messages[1].sender, 'sender1')
+        self.assertEqual(messages[1].content, 'text second')
+        self.assertEqual(messages[1].received_at, datetime.fromisoformat('2024-11-15 22:28:09'))
+        self.assertEqual(messages[1].unread, True)
+
+    def test_get_sms_empty(self) -> None:
+        DEV2_LTE_SMS_RECVMSGBOX = ('{"data":{"totalNumber":"0","unreadNumber":"0","pageNumber":"0",'
+                                   '"amountPerPage":"0","stack":"0,0,0,0,0,0"},"operation":"go",'
+                                   '"oid":"DEV2_LTE_SMS_RECVMSGBOX","success":true}')
+
+        class TPLinkEXClientTest(TPLinkEXClient):
+            def _request(self, url, method='POST', data_str=None, encrypt=False):
+                if 'DEV2_LTE_SMS_RECVMSGBOX' in data_str:
+                    return 200, DEV2_LTE_SMS_RECVMSGBOX
+                raise ClientException()
+
+        client = TPLinkEXClientTest('', '')
+        messages = client.get_sms()
+
+        self.assertEqual(messages, [])
+
+    def test_set_sms_read(self) -> None:
+        DEV2_LTE_SMS_RECVMSGBOX = ('{"data":{"totalNumber":"2","unreadNumber":"0","pageNumber":"0",'
+                                   '"amountPerPage":"0","stack":"0,0,0,0,0,0"},"operation":"go",'
+                                   '"oid":"DEV2_LTE_SMS_RECVMSGBOX","success":true}')
+        DEV2_LTE_SMS_RECVMSGENTRY = ('{"data":[{"index":"2","from":"sender2","content":"text first",'
+                                     '"receivedTime":"2024-11-15 22:23:59","unread":"0",'
+                                     '"stack":"2,0,0,0,0,0"},{"index":"1","from":"sender1",'
+                                     '"content":"text second","receivedTime":"2024-11-15 22:28:09",'
+                                     '"unread":"1","stack":"1,0,0,0,0,0"}],'
+                                     '"operation":"gl","oid":"DEV2_LTE_SMS_RECVMSGENTRY","success":true}')
+
+        check_url = ''
+        check_data = ''
+
+        class TPLinkEXClientTest(TPLinkEXClient):
+            def _request(self, url, method='POST', data_str=None, encrypt=False):
+                nonlocal check_url, check_data
+                if 'DEV2_LTE_SMS_RECVMSGBOX' in data_str and '"operation":"go"' in data_str:
+                    return 200, DEV2_LTE_SMS_RECVMSGBOX
+                elif 'DEV2_LTE_SMS_RECVMSGBOX' in data_str:
+                    return 200, '{}'
+                elif 'DEV2_LTE_SMS_RECVMSGENTRY' in data_str and '"operation":"gl"' in data_str:
+                    return 200, DEV2_LTE_SMS_RECVMSGENTRY
+                elif 'DEV2_LTE_SMS_RECVMSGENTRY' in data_str and '"operation":"so"' in data_str:
+                    check_url = url
+                    check_data = data_str
+                    return 200, '{}'
+                raise ClientException()
+
+        client = TPLinkEXClientTest('', '')
+        client.set_sms_read(SMS(2, '', '', datetime.now(), True))
+
+        self.assertIn('http:///cgi_gdpr?9?_', check_url)
+        self.assertEqual(check_data, ('{"data":{"stack":"2,0,0,0,0,0","pstack":"0,0,0,0,0,0","unread":"0"},'
+                                     '"operation":"so","oid":"DEV2_LTE_SMS_RECVMSGENTRY"}'))
+
+    def test_delete_sms(self) -> None:
+        DEV2_LTE_SMS_RECVMSGBOX = ('{"data":{"totalNumber":"2","unreadNumber":"0","pageNumber":"0",'
+                                   '"amountPerPage":"0","stack":"0,0,0,0,0,0"},"operation":"go",'
+                                   '"oid":"DEV2_LTE_SMS_RECVMSGBOX","success":true}')
+        DEV2_LTE_SMS_RECVMSGENTRY = ('{"data":[{"index":"2","from":"sender2","content":"text first",'
+                                     '"receivedTime":"2024-11-15 22:23:59","unread":"0",'
+                                     '"stack":"2,0,0,0,0,0"},{"index":"1","from":"sender1",'
+                                     '"content":"text second","receivedTime":"2024-11-15 22:28:09",'
+                                     '"unread":"1","stack":"1,0,0,0,0,0"}],'
+                                     '"operation":"gl","oid":"DEV2_LTE_SMS_RECVMSGENTRY","success":true}')
+
+        check_url = ''
+        check_data = ''
+
+        class TPLinkEXClientTest(TPLinkEXClient):
+            def _request(self, url, method='POST', data_str=None, encrypt=False):
+                nonlocal check_url, check_data
+                if 'DEV2_LTE_SMS_RECVMSGBOX' in data_str and '"operation":"go"' in data_str:
+                    return 200, DEV2_LTE_SMS_RECVMSGBOX
+                elif 'DEV2_LTE_SMS_RECVMSGBOX' in data_str:
+                    return 200, '{}'
+                elif 'DEV2_LTE_SMS_RECVMSGENTRY' in data_str and '"operation":"gl"' in data_str:
+                    return 200, DEV2_LTE_SMS_RECVMSGENTRY
+                elif 'DEV2_LTE_SMS_RECVMSGENTRY' in data_str and '"operation":"do"' in data_str:
+                    check_url = url
+                    check_data = data_str
+                    return 200, '{}'
+                raise ClientException()
+
+        client = TPLinkEXClientTest('', '')
+        client.delete_sms(SMS(2, '', '', datetime.now(), True))
+
+        self.assertIn('http:///cgi_gdpr?9?_', check_url)
+        self.assertEqual(check_data, ('{"data":{"stack":"2,0,0,0,0,0","pstack":"0,0,0,0,0,0"},'
+                                     '"operation":"do","oid":"DEV2_LTE_SMS_RECVMSGENTRY"}'))
 
 
 if __name__ == '__main__':

--- a/tplinkrouterc6u/client/ex.py
+++ b/tplinkrouterc6u/client/ex.py
@@ -1,6 +1,7 @@
 from base64 import b64encode
 from json import loads
-from datetime import timedelta
+from datetime import timedelta, datetime
+from typing import List
 from logging import Logger
 from tplinkrouterc6u.common.package_enum import Connection, VPN
 from tplinkrouterc6u.common.helper import get_ip, get_mac, get_value
@@ -12,6 +13,7 @@ from tplinkrouterc6u.common.dataclass import (
     IPv4DHCPLease,
     IPv4Status,
     LTEStatus,
+    SMS,
     VPNStatus)
 from tplinkrouterc6u.common.exception import ClientException, ClientError
 from tplinkrouterc6u.client.mr import TPLinkMRClientBase, TPLinkMRClientBaseGCM
@@ -32,6 +34,7 @@ class TPLinkEXClient(TPLinkMRClientBase):
         SET = 'so'
         ADD = 'add'
         DEL = 'del'
+        DO = 'do'
         GL = 'gl'
         GS = 'gs'
         OP = 'op'
@@ -297,6 +300,85 @@ class TPLinkEXClient(TPLinkMRClientBase):
                     f'"to":"{phone_number}"',
                     f'"textContent":"{message}"',
                 ]),
+        ]
+        self.req_act(acts)
+
+    def _fetch_sms_entries(self) -> list[tuple[int, dict]]:
+        acts = [
+            self.ActItem(self.ActItem.GO, 'DEV2_LTE_SMS_RECVMSGBOX'),
+        ]
+        _, values = self.req_act(acts)
+
+        total_number = int(values[0]['totalNumber']) if values else 0
+        if total_number == 0:
+            return []
+
+        sms_attrs = ['index', 'from', 'content', 'receivedTime', 'unread']
+        page_size = 8
+        num_pages = (total_number + page_size - 1) // page_size
+
+        entries = []
+        for page in range(1, num_pages + 1):
+            acts = [
+                self.ActItem(
+                    self.ActItem.SET, 'DEV2_LTE_SMS_RECVMSGBOX',
+                    attrs=[f'"pageNumber":"{page}"']),
+                self.ActItem(
+                    self.ActItem.GL, 'DEV2_LTE_SMS_RECVMSGENTRY', attrs=sms_attrs),
+            ]
+            _, values = self.req_act(acts)
+
+            for item in self._to_list(values[0]):
+                entries.append((page, item))
+
+        return entries
+
+    def _resolve_sms(self, sms: SMS) -> tuple[int, str]:
+        for page, item in self._fetch_sms_entries():
+            if int(item['index']) == sms.id:
+                return page, item['stack']
+
+        raise ClientError(f'SMS not found: index {sms.id}')
+
+    def get_sms(self) -> List[SMS]:
+        messages = []
+        for _, item in self._fetch_sms_entries():
+            messages.append(
+                SMS(
+                    int(item['index']),
+                    item['from'],
+                    item['content'],
+                    datetime.fromisoformat(item['receivedTime']),
+                    item['unread'] == '1',
+                )
+            )
+
+        return messages
+
+    def set_sms_read(self, sms: SMS) -> None:
+        page, stack = self._resolve_sms(sms)
+        acts = [
+            self.ActItem(
+                self.ActItem.SET, 'DEV2_LTE_SMS_RECVMSGBOX',
+                attrs=[f'"pageNumber":"{page}"']),
+            self.ActItem(
+                self.ActItem.SET, 'DEV2_LTE_SMS_RECVMSGENTRY',
+                stack=stack,
+                attrs=['"unread":"0"'],
+            ),
+        ]
+        self.req_act(acts)
+
+    def delete_sms(self, sms: SMS) -> None:
+        page, stack = self._resolve_sms(sms)
+        acts = [
+            self.ActItem(
+                self.ActItem.SET, 'DEV2_LTE_SMS_RECVMSGBOX',
+                attrs=[f'"pageNumber":"{page}"']),
+            self.ActItem(
+                self.ActItem.DO, 'DEV2_LTE_SMS_RECVMSGENTRY',
+                stack=stack,
+            ),
         ]
         self.req_act(acts)
 


### PR DESCRIPTION
hello, i implemented a few more methods for sms. now you should be able to get in the inbox as a list and mark single ones as read or delete them.

pagination behaves a bit tricky and to select a specific sms you have to provide a page and stack number. because this is not stable (for example after deleting one) it is necessary to always get the newest state of the sms list to do it beforehand. this may result in a lot of fetch calls, when doing bulk "mark as read" or "delete" operations.