### PR TITLE
Fix TPLinkRClient handling of offline clients without IP addresses

### DIFF
--- a/test/test_client_r.py
+++ b/test/test_client_r.py
@@ -331,7 +331,6 @@ $(document).ready(function(e){
           ".name": "2EDE61E7EA70",
           "up_speed": "0",
           "host_save": "on",
-          "ip": "192.168.60.212",
           "time_obj": "any",
           "is_cur_host": "false",
           "limit": "0",
@@ -434,6 +433,10 @@ $(document).ready(function(e){
         self.assertEqual(status.devices[0].ipaddr, '192.168.60.112')
         self.assertIsInstance(status.devices[0].ipaddress, IPv4Address)
         self.assertEqual(status.devices[0].hostname, 'iPhone')
+        self.assertEqual(status.devices[0].ap_name, 'xxx-ap')
+        self.assertEqual(status.devices[0].ssid, 'xxx')
+        self.assertEqual(status.devices[0].frequency, '5GHz')
+        self.assertEqual(status.devices[0].signal, -77)
         self.assertIsInstance(status.devices[1], Device)
         self.assertEqual(status.devices[1].type, Connection.HOST_2G)
         self.assertEqual(status.devices[1].macaddr, '44-23-7C-8F-C2-42')
@@ -444,6 +447,8 @@ $(document).ready(function(e){
         self.assertIsInstance(status.devices[4], Device)
         self.assertEqual(status.devices[4].active, False)
         self.assertEqual(status.devices[4].type, Connection.UNKNOWN)
+        self.assertIsNone(status.devices[4].ipaddr)
+        self.assertIsNone(status.devices[4].ipaddress)
 
     def test_set_wifi_enable_guest_2g(self) -> None:
         mock_data = json.loads('''{"error_code":0}''')

--- a/tplinkrouterc6u/client/r.py
+++ b/tplinkrouterc6u/client/r.py
@@ -98,15 +98,24 @@ class TPLinkRClient(TPLinkXDRClient):
                 conn_type = Connection.HOST_5G
                 status.wifi_clients_total += 1
 
-            dev = Device(conn_type, get_mac(item['mac']), get_ip(item['ip']), unquote(item['hostname']))
+            ipaddr = get_ip(item['ip']) if item.get('ip') else None
+            dev = Device(conn_type, get_mac(item['mac']), ipaddr, unquote(item['hostname']))
             if 'up_speed' in item:
                 dev.up_speed = int(item['up_speed'])
             if 'down_speed' in item:
                 dev.down_speed = int(item['down_speed'])
-            if 'signal' in item:
+            if 'rssi' in item:
                 dev.signal = int(item['rssi'])
+            elif 'signal' in item:
+                dev.signal = int(item['signal'])
             if 'state' in item:
                 dev.active = item['state'] == 'online'
+            if 'ap_name' in item:
+                dev.ap_name = unquote(item['ap_name'])
+            if 'ssid' in item:
+                dev.ssid = unquote(item['ssid'])
+            if 'freq_name' in item:
+                dev.frequency = item['freq_name']
             status.devices.append(dev)
         return status
 

--- a/tplinkrouterc6u/common/dataclass.py
+++ b/tplinkrouterc6u/common/dataclass.py
@@ -17,7 +17,7 @@ class Firmware:
 class Device:
     type: Connection
     _macaddr: EUI48
-    _ipaddr: IPv4Address
+    _ipaddr: IPv4Address | None
     hostname: str
     packets_sent: int | None = None
     packets_received: int | None = None
@@ -29,6 +29,9 @@ class Device:
     traffic_usage: int | None = None
     signal: int | None = None
     active: bool = True
+    ap_name: str | None = None
+    ssid: str | None = None
+    frequency: str | None = None
 
     @property
     def macaddr(self):
@@ -40,7 +43,7 @@ class Device:
 
     @property
     def ipaddr(self):
-        return str(self._ipaddr)
+        return str(self._ipaddr) if self._ipaddr else None
 
     @property
     def ipaddress(self):


### PR DESCRIPTION
## Summary

- Allow `TPLinkRClient.get_status()` to parse offline host entries that do not include an `ip` field.
- Preserve TP-Link AC/AP metadata on `Device`: `ap_name`, `ssid`, and `frequency`.
- Prefer `rssi` as the signal source for TP-Link R/AC host entries while keeping `signal` as a fallback.

## Why

Some TP-Link R/AC firmwares return offline entries in `host_management.host_info` with a MAC, hostname, type, and state, but without `ip`. The previous parser raised `KeyError: ip`, which prevents Home Assistant integrations from setting up even though most clients are readable.

## Validation

- `python3 -m unittest test.test_client_r.TestTPLinkRClient.test_get_status -v`
- `python3 -m unittest discover -s test -v`

Both pass locally; full suite: 314 tests OK.