### PR TITLE
Add add_ipv4_reservation() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ or you have TP-link C5400X or similar router you need to get web encrypted passw
 | get_status |   | Gets status about the router info including wifi statuses and connected devices info | [Status](#status) |
 | get_ipv4_status |   | Gets WAN and LAN IPv4 status info, gateway, DNS, netmask | [IPv4Status](#IPv4Status) |
 | get_ipv4_reservations |   | Gets IPv4 reserved addresses (static) | [[IPv4Reservation]](#IPv4Reservation) |
+| add_ipv4_reservation | macaddr: str, ipaddr: str, comment: str = '', enable: bool = True | Adds an IPv4 DHCP address reservation |   |
 | get_ipv4_dhcp_leases |   | Gets IPv4 addresses assigned via DHCP | [[IPv4DHCPLease]](#IPv4DHCPLease) | 
 | set_wifi | wifi: [Connection](#connection), enable: bool | Allow to turn on/of 4 wifi networks |   |
 | reboot |   | reboot router |

--- a/test/test_client_c6u.py
+++ b/test/test_client_c6u.py
@@ -860,6 +860,36 @@ class TestTPLinkClient(TestCase):
         self.assertEqual(check_url, 'admin/wireless?form=iot_6g')
         self.assertEqual(check_data, 'operation=write&enable=on')
 
+    def test_add_ipv4_reservation(self) -> None:
+        check_url = ''
+        check_data = ''
+        router_class = self.router_class
+
+        class TPLinkRouterTest(router_class):
+            def request(self, path: str, data: str,
+                        ignore_response: bool = False, ignore_errors: bool = False) -> dict | None:
+                nonlocal check_url, check_data
+                check_url = path
+                check_data = data
+                return None
+
+        client = TPLinkRouterTest('', '')
+        result = client.add_ipv4_reservation('02:00:00:00:00:16', '10.0.0.116', 'auto')
+        self.assertIsNone(result)
+        self.assertEqual(check_url, 'admin/dhcps?form=reservation')
+        body = dict(parse_qsl(check_data))
+        self.assertEqual(body['operation'], 'insert')
+        self.assertEqual(
+            loads(body['new']),
+            {'mac': '02-00-00-00-00-16', 'ip': '10.0.0.116', 'comment': 'auto', 'enable': 'on'})
+
+        # MAC is normalised to dash-uppercase and a disabled entry sends enable=off
+        client.add_ipv4_reservation('aa-bb-cc-dd-ee-ff', '10.0.0.50', enable=False)
+        body = dict(parse_qsl(check_data))
+        self.assertEqual(
+            loads(body['new']),
+            {'mac': 'AA-BB-CC-DD-EE-FF', 'ip': '10.0.0.50', 'comment': '', 'enable': 'off'})
+
     def test_get_ipv4_status_empty(self) -> None:
         response_network = '{"result": {}, "error_code": 0}'
         router_class = self.router_class

--- a/tplinkrouterc6u/client/c6u.py
+++ b/tplinkrouterc6u/client/c6u.py
@@ -425,6 +425,21 @@ class TplinkBaseRouter(AbstractRouter, TplinkRequest):
 
         return ipv4_reservations
 
+    def add_ipv4_reservation(self, macaddr: str, ipaddr: str, comment: str = '', enable: bool = True) -> None:
+        """Add an IPv4 DHCP address reservation.
+
+        macaddr may be given in any common format (colon/dash, upper/lower);
+        it is normalised to the dash-uppercase form the router stores.
+        """
+        path = self._url_ipv4_reservations.split('&operation=')[0]
+        new = dumps({
+            'mac': str(get_mac(macaddr)),
+            'ip': ipaddr,
+            'comment': comment,
+            'enable': 'on' if enable else 'off',
+        })
+        self.request(path, urlencode({'operation': 'insert', 'new': new}))
+
     def get_ipv4_dhcp_leases(self) -> [IPv4DHCPLease]:
         dhcp_leases = []
         data = self.request(self._url_ipv4_dhcp_leases, 'operation=load')


### PR DESCRIPTION
## What
Adds `add_ipv4_reservation(macaddr, ipaddr, comment="", enable=True)` to `TplinkBaseRouter`. The library could already read reservations via `get_ipv4_reservations()` but had no way to create them.

## How
The reservation form (`admin/dhcps?form=reservation`) accepts an add via `operation=insert` with a `new=<json>` payload of `{mac, ip, comment, enable}` — the same `new`-parameter pattern already used by `set_vpn_client_device`. The MAC is normalised to the dash-uppercase form the firmware stores (via the existing `get_mac` helper).

Found by probing operation verbs: `add`/`write` return `{"errorcode": "no such callback"}`, while `insert` returns `{"errorcode": "invalid new params"}`, which pointed at the required `new` field. Confirmed end-to-end on an **Archer AX53**.

## Tests
Adds `test_add_ipv4_reservation` (asserts endpoint, `operation=insert`, JSON `new` payload, MAC normalisation, `enable=off`). Full `test_client_c6u` suite passes; flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
