### PR TITLE
Add WAN IPv6 support for MR client (tested on VR1600v v1, f/w v2.1.0)

### DIFF
--- a/tplinkrouterc6u/__init__.py
+++ b/tplinkrouterc6u/__init__.py
@@ -31,6 +31,7 @@ from tplinkrouterc6u.common.dataclass import (
     IPv4Reservation,
     IPv4DHCPLease,
     IPv4Status,
+    IPv6Status,
     SMS,
     LTEStatus,
     VPNStatus,

--- a/tplinkrouterc6u/client/c6u.py
+++ b/tplinkrouterc6u/client/c6u.py
@@ -6,7 +6,7 @@ from requests import post, Response
 from logging import Logger
 from urllib.parse import parse_qsl
 from json import dumps
-from tplinkrouterc6u.common.helper import get_ip, get_mac
+from tplinkrouterc6u.common.helper import get_ip, get_ipv6, get_mac
 from tplinkrouterc6u.common.encryption import EncryptionWrapper
 from tplinkrouterc6u.common.package_enum import Connection, VPN, VpnClientServerProtocol
 from tplinkrouterc6u.common.dataclass import (
@@ -16,6 +16,7 @@ from tplinkrouterc6u.common.dataclass import (
     IPv4Reservation,
     IPv4DHCPLease,
     IPv4Status,
+    IPv6Status,
     VPNStatus,
     VpnClientStatus,
     VpnClientServer,

--- a/tplinkrouterc6u/client/mr.py
+++ b/tplinkrouterc6u/client/mr.py
@@ -5,7 +5,7 @@ from urllib.parse import quote
 from requests import Session, Response
 from datetime import timedelta, datetime
 from logging import Logger
-from tplinkrouterc6u.common.helper import get_ip, get_mac, get_value
+from tplinkrouterc6u.common.helper import get_ip, get_ipv6, get_mac, get_value
 from tplinkrouterc6u.common.encryption import EncryptionWrapperMR, EncryptionWrapperMRGCM
 from tplinkrouterc6u.common.package_enum import Connection, VPN
 from tplinkrouterc6u.common.dataclass import (
@@ -15,6 +15,7 @@ from tplinkrouterc6u.common.dataclass import (
     IPv4Reservation,
     IPv4DHCPLease,
     IPv4Status,
+    IPv6Status,
     SMS,
     LTEStatus,
     VPNStatus,
@@ -152,7 +153,7 @@ class TPLinkMRClientBase(AbstractRouter):
         acts = [
             self.ActItem(self.ActItem.GS, 'LAN_IP_INTF', attrs=['X_TP_MACAddress', 'IPInterfaceIPAddress']),
             self.ActItem(self.ActItem.GS, 'WAN_IP_CONN',
-                         attrs=['enable', 'MACAddress', 'externalIPAddress', 'defaultGateway', 'name']),
+                         attrs=['enable', 'MACAddress', 'externalIPAddress', 'X_TP_ExternalIPv6Address', 'defaultGateway', 'name']),
             self.ActItem(self.ActItem.GL, 'LAN_WLAN', attrs=['enable', 'X_TP_Band']),
             self.ActItem(self.ActItem.GL, 'LAN_WLAN_GUESTNET', attrs=['enable', 'name']),
             self.ActItem(self.ActItem.GL, 'LAN_HOST_ENTRY', attrs=[
@@ -182,6 +183,7 @@ class TPLinkMRClientBase(AbstractRouter):
             status._wan_macaddr = get_mac(item['MACAddress']) if item.get('MACAddress') else None
             status._wan_ipv4_addr = get_ip(item['externalIPAddress'])
             status._wan_ipv4_gateway = get_ip(item['defaultGateway'])
+            status._wan_ipv6_addr = get_ipv6(item['X_TP_ExternalIPv6Address'])
             status.conn_type = item.get('name', '')
 
         if values['2'].__class__ != list:
@@ -312,6 +314,31 @@ class TPLinkMRClientBase(AbstractRouter):
 
         return ipv4_status
 
+    def get_ipv6_status(self) -> IPv6Status:
+        acts = [
+           self.ActItem(self.ActItem.GS, 'WAN_IP_CONN',
+                         attrs=['enable', 'X_TP_IPv6ConnStatus', 'X_TP_IPv6AddressingType', 'X_TP_ExternalIPv6Address', 'X_TP_PrefixLength', 'X_TP_DefaultIPv6Gateway', 'X_TP_SitePrefix', 'X_TP_SitePrefixLength', 'X_TP_IPv6DNSServers'])
+        ]
+        _, values = self.req_act(acts)
+
+        ipv6_status = IPv6Status()
+
+        for item in self._to_list(values):
+            if int(item.get('enable', '0')) == 0:
+                continue
+            ipv6_status._wan_ipv6_conn_status = item.get('X_TP_IPv6ConnStatus', '')
+            ipv6_status._wan_ipv6_addr_type = item.get('X_TP_IPv6AddressingType', '')
+            ipv6_status._wan_ipv6_ipaddr = get_ipv6(item.get('X_TP_ExternalIPv6Address', '::'))
+            ipv6_status._wan_ipv6_prefix_length = item.get('X_TP_PrefixLength')
+            ipv6_status._wan_ipv6_gateway = get_ipv6(item.get('X_TP_DefaultIPv6Gateway', '::'))
+            ipv6_status._wan_ipv6_site_prefix = get_ipv6(item.get('X_TP_SitePrefix', '::'))
+            ipv6_status._wan_ipv6_site_prefix_length = item.get('X_TP_SitePrefixLength')
+            ipv6_dns = item.get('X_TP_IPv6DNSServers', '').split(',')
+            ipv6_status._wan_ipv6_pridns_address = get_ipv6(ipv6_dns[0] if len(ipv6_dns) > 0 else '::')
+            ipv6_status._wan_ipv6_secdns_address = get_ipv6(ipv6_dns[1] if len(ipv6_dns) > 0 else '::')
+
+        return ipv6_status
+    
     def set_wifi(self, wifi: Connection, enable: bool) -> None:
         acts = [
             self.ActItem(

--- a/tplinkrouterc6u/client_abstract.py
+++ b/tplinkrouterc6u/client_abstract.py
@@ -1,7 +1,7 @@
 from requests.packages import urllib3
 from logging import Logger
 from tplinkrouterc6u.common.package_enum import Connection
-from tplinkrouterc6u.common.dataclass import Firmware, Status, IPv4Status
+from tplinkrouterc6u.common.dataclass import Firmware, Status, IPv4Status, IPv6Status
 from abc import ABC, abstractmethod
 
 
@@ -43,6 +43,10 @@ class AbstractRouter(ABC):
     def get_ipv4_status(self) -> IPv4Status:
         pass
 
+    @abstractmethod
+    def get_ipv6_status(self) -> IPv6Status:
+        pass
+    
     @abstractmethod
     def reboot(self) -> None:
         pass

--- a/tplinkrouterc6u/client_abstract.py
+++ b/tplinkrouterc6u/client_abstract.py
@@ -44,10 +44,6 @@ class AbstractRouter(ABC):
         pass
 
     @abstractmethod
-    def get_ipv6_status(self) -> IPv6Status:
-        pass
-    
-    @abstractmethod
     def reboot(self) -> None:
         pass
 

--- a/tplinkrouterc6u/common/dataclass.py
+++ b/tplinkrouterc6u/common/dataclass.py
@@ -100,6 +100,10 @@ class Status:
         return self._wan_ipv4_addr
 
     @property
+    def wan_ipv6_addr(self) -> str | None:
+        return str(self._wan_ipv6_addr) if self._wan_ipv6_addr else None
+
+    @property
     def lan_ipv4_addr(self) -> str | None:
         return str(self._lan_ipv4_addr) if self._lan_ipv4_addr else None
 

--- a/tplinkrouterc6u/common/dataclass.py
+++ b/tplinkrouterc6u/common/dataclass.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from macaddress import EUI48
-from ipaddress import IPv4Address
+from ipaddress import IPv4Address, IPv6Address
 from dataclasses import dataclass, field
 from datetime import datetime
 from tplinkrouterc6u.common.package_enum import Connection, VpnClientServerProtocol
@@ -54,6 +54,7 @@ class Status:
     _wan_ipv4_addr: IPv4Address | None = None
     _lan_ipv4_addr: IPv4Address | None = None
     _wan_ipv4_gateway: IPv4Address | None = None
+    _wan_ipv6_addr: IPv6Address | None = None
     wired_total: int = 0
     wifi_clients_total: int = 0
     guest_clients_total: int = 0
@@ -253,6 +254,47 @@ class IPv4Status:
     @property
     def lan_ipv4_netmask_address(self):
         return self._lan_ipv4_netmask
+
+
+@dataclass
+class IPv6Status:
+    _wan_ipv6_conn_status: str = ""
+    _wan_ipv6_addr_type: str = ""
+    _wan_ipv6_ipaddr: IPv6Address | None = None
+    _wan_ipv6_prefix_length: int = 0
+    _wan_ipv6_gateway: IPv6Address | None = None
+    _wan_ipv6_site_prefix: IPv6Address | None = None
+    _wan_ipv6_site_prefix_length: int = 0
+    _wan_ipv6_pridns_address: IPv6Address | None = None
+    _wan_ipv6_secdns_address: IPv6Address | None = None
+    
+    @property
+    def wan_ipv6_conn_status(self):
+        return str(self._wan_ipv6_conn_status) if self._wan_ipv6_conn_status else None
+    @property
+    def wan_ipv6_addr_type(self):
+        return str(self._wan_ipv6_addr_type) if self._wan_ipv6_addr_type else None
+    @property
+    def wan_ipv6_ipaddr(self):
+        return str(self._wan_ipv6_ipaddr) if self._wan_ipv6_ipaddr else None
+    @property
+    def wan_ipv6_prefix_length(self):
+        return str(self._wan_ipv6_prefix_length)
+    @property
+    def wan_ipv6_gateway(self):
+        return str(self._wan_ipv6_gateway) if self._wan_ipv6_gateway else None
+    @property
+    def wan_ipv6_site_prefix(self):
+        return str(self._wan_ipv6_site_prefix)
+    @property
+    def wan_ipv6_site_prefix_length(self):
+        return str(self._wan_ipv6_site_prefix_length)
+    @property
+    def wan_ipv6_pridns_address(self):
+        return self._wan_ipv6_pridns_address
+    @property
+    def wan_ipv6_secdns_address(self):
+        return self._wan_ipv6_secdns_address
 
 
 @dataclass

--- a/tplinkrouterc6u/common/helper.py
+++ b/tplinkrouterc6u/common/helper.py
@@ -1,4 +1,4 @@
-from ipaddress import IPv4Address
+from ipaddress import IPv4Address, IPv6Address
 from macaddress import EUI48
 
 
@@ -7,6 +7,13 @@ def get_ip(ip: str) -> IPv4Address:
         return IPv4Address(ip)
     except Exception:
         return IPv4Address('0.0.0.0')
+
+
+def get_ipv6(ip: str) -> IPv6Address:
+    try:
+        return IPv6Address(ip)
+    except Exception:
+        return IPv6Address('::')
 
 
 def get_mac(mac: str) -> EUI48:


### PR DESCRIPTION
This adds IPv6 WAN support for routers which use MR Client.
A new method, get_ipv6_status, is added to MR Client Base, returning several fields.
The standard get_status method has just one new field - the WAN IPv6 address.  I found it a useful indication of whether the IPv6 connection is active on a dual stack ISP service.
Both methods have been tested successfully using an Archer VR1600v v1, with firmware v2.1.0.