### PR TITLE
fix: accept both list shapes for IPv4 reservations and DHCP leases (Archer BE805 v1.20)

### DIFF
--- a/test/test_client_c6u.py
+++ b/test/test_client_c6u.py
@@ -1,4 +1,5 @@
 from unittest import main, TestCase
+from unittest.mock import patch, Mock
 from macaddress import EUI48
 from ipaddress import IPv4Address
 from json import loads
@@ -15,6 +16,7 @@ from tplinkrouterc6u import (
     VpnClientServer,
     VpnClientDevice,
 )
+from tplinkrouterc6u.common.exception import ClientError
 
 
 class TestTPLinkClient(TestCase):
@@ -1368,3 +1370,54 @@ class TestTPLinkClient(TestCase):
 
 if __name__ == '__main__':
     main()
+
+
+class TestIPv4ListEnvelope(TestCase):
+    """Both response shapes must work: firmware differs, so neither may be assumed.
+
+    An Archer BE805 v1.20 on 1.5.1 Build 20260523 rel.11659(5347) answers the
+    reservation load with {"list": [...]}, while other models answer with a bare
+    array. Iterating the response directly walks dict KEYS on the former, so the
+    first item['mac'] raises TypeError.
+    """
+
+    @patch('tplinkrouterc6u.client.c6u.TplinkBaseRouter.request')
+    def test_reservations_accept_bare_list(self, mock_request: Mock) -> None:
+        mock_request.return_value = [
+            {'mac': '02-00-00-00-00-01', 'ip': '10.0.0.1', 'comment': 'a', 'enable': 'on'},
+        ]
+        client = TplinkRouter('http://192.168.0.1', 'password')
+        result = client.get_ipv4_reservations()
+        self.assertEqual(len(result), 1)
+        self.assertEqual(str(result[0].macaddr), '02-00-00-00-00-01')
+
+    @patch('tplinkrouterc6u.client.c6u.TplinkBaseRouter.request')
+    def test_reservations_accept_list_envelope(self, mock_request: Mock) -> None:
+        mock_request.return_value = {'list': [
+            {'mac': '02-00-00-00-00-02', 'ip': '10.0.0.2', 'comment': 'b', 'enable': 'on',
+             'hostname': 'host', 'key': 'k'},
+        ]}
+        client = TplinkRouter('http://192.168.0.1', 'password')
+        result = client.get_ipv4_reservations()
+        self.assertEqual(len(result), 1)
+        self.assertEqual(str(result[0].macaddr), '02-00-00-00-00-02')
+
+    @patch('tplinkrouterc6u.client.c6u.TplinkBaseRouter.request')
+    def test_reservations_reject_unknown_shape(self, mock_request: Mock) -> None:
+        # A clear error beats TypeError from three frames deeper: the message
+        # names the keys actually received, which is what a bug report needs.
+        mock_request.return_value = {'unexpected': []}
+        client = TplinkRouter('http://192.168.0.1', 'password')
+        with self.assertRaises(ClientError) as ctx:
+            client.get_ipv4_reservations()
+        self.assertIn('unexpected', str(ctx.exception))
+
+    @patch('tplinkrouterc6u.client.c6u.TplinkBaseRouter.request')
+    def test_leases_accept_both_shapes(self, mock_request: Mock) -> None:
+        lease = {'macaddr': '02-00-00-00-00-03', 'ipaddr': '10.0.0.3',
+                 'name': 'n', 'leasetime': '1:00:00'}
+        client = TplinkRouter('http://192.168.0.1', 'password')
+        mock_request.return_value = [lease]
+        self.assertEqual(len(client.get_ipv4_dhcp_leases()), 1)
+        mock_request.return_value = {'dhcp_clients': [lease]}
+        self.assertEqual(len(client.get_ipv4_dhcp_leases()), 1)

--- a/tplinkrouterc6u/client/c6u.py
+++ b/tplinkrouterc6u/client/c6u.py
@@ -414,11 +414,39 @@ class TplinkBaseRouter(AbstractRouter, TplinkRequest):
 
         return ipv4_status
 
+    @staticmethod
+    def _as_list(data, envelope_key: str, what: str) -> list:
+        """Return a list payload whether or not the router wrapped it.
+
+        Some firmware answers these `operation=load` calls with a bare JSON
+        array, and some wraps it as ``{"<key>": [...]}``. Observed on an Archer
+        BE805 v1.20 running 1.5.1 Build 20260523 rel.11659(5347), where the
+        reservation payload arrives as ``{"list": [...]}`` and iterating the
+        response directly yields dict *keys*, so the first ``item['mac']``
+        raises ``TypeError: string indices must be integers``.
+
+        Both shapes are accepted rather than one being replaced by the other:
+        these payloads are model- and firmware-specific, and swapping the
+        assumption would simply move the failure to whichever routers answer the
+        other way.
+        """
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict):
+            value = data.get(envelope_key)
+            if isinstance(value, list):
+                return value
+            raise ClientError(
+                '{} response is an object without a list "{}"; got keys {}'
+                .format(what, envelope_key, sorted(data.keys())))
+        raise ClientError('{} response is neither a list nor an object; got {}'
+                          .format(what, type(data).__name__))
+
     def get_ipv4_reservations(self) -> [IPv4Reservation]:
         ipv4_reservations = []
         data = self.request(self._url_ipv4_reservations, 'operation=load')
 
-        for item in data:
+        for item in self._as_list(data, 'list', 'IPv4 reservation'):
             ipv4_reservations.append(
                 IPv4Reservation(get_mac(item['mac']), get_ip(item['ip']), item['comment'],
                                 self._str2bool(item['enable'])))
@@ -444,7 +472,7 @@ class TplinkBaseRouter(AbstractRouter, TplinkRequest):
         dhcp_leases = []
         data = self.request(self._url_ipv4_dhcp_leases, 'operation=load')
 
-        for item in data:
+        for item in self._as_list(data, 'dhcp_clients', 'DHCP lease'):
             dhcp_leases.append(
                 IPv4DHCPLease(get_mac(item['macaddr']), get_ip(item['ipaddr']), item['name'],
                               item['leasetime']))


### PR DESCRIPTION
### Problem

`get_ipv4_reservations()` raises on an **Archer BE805 v1.20**, firmware **`1.5.1 Build 20260523 rel.11659(5347)`** (resolved client: `TplinkRouterV1_11`):

```
TypeError: string indices must be integers, not 'str'
```

### Cause

That firmware answers `admin/dhcps?form=reservation&operation=load` with an **envelope** rather than a bare array:

```
raw type    : dict
raw keys    : ['list']
raw['list'] : list[21] of dict
element keys: ['comment', 'enable', 'hostname', 'ip', 'key', 'mac']
```

`for item in data:` therefore iterates the dict's **keys**, and the first `item['mac']` subscripts a string. The payload itself is perfectly healthy — all 21 reservations are present with the expected fields.

### Approach — additive, not substitutive

Changing `data` to `data['list']` would fix this model and **break every router that answers with a bare array**. These response shapes are model- and firmware-specific, so the fix accepts either.

A small shared `_as_list()` helper:

- returns the payload unchanged when it is already a list — **no behaviour change for existing devices**
- unwraps `{"<key>": [...]}` when the router wraps it
- otherwise raises `ClientError` naming the keys actually received, which is considerably more useful in a bug report than a `TypeError` three frames deeper

Applied to `get_ipv4_dhcp_leases()` as well. It has the identical pattern and happens to work on this firmware, but leaving the same latent bug next door only defers it, and a bare array passes through untouched.

### Testing

Verified on real hardware: Archer BE805 v1.20, firmware
1.5.1 Build 20260523 rel.11659(5347), client `TplinkRouterV1_11`.
Before: `TypeError: string indices must be integers, not 'str'`.
After: all 21 reservations returned; leases still 15.
323 existing tests pass, 4 added.

Thanks for the library; adding BE805 support made this device usable at all.