### PR TITLE
Add get_lte_serving_cells() to TPLinkMRClient

### DIFF
--- a/test/test_client_ex.py
+++ b/test/test_client_ex.py
@@ -882,6 +882,56 @@ class TestTPLinkEXClient(TestCase):
         self.assertEqual(status.snr, 270)
         self.assertEqual(status.isp_name, 'O2 2025')
 
+    def test_get_lte_serving_cells(self) -> None:
+        DEV2_LTE_SERVING_CELL_INFO = (
+            '{"data":[{"networkType": "3", "cellConnectionStatus": "1", "band": "3", "ARFCN": "1300",'
+            '"downBandWidth": "20000", "downFreq": "1815", "downlinkModType": "QPSK", "uplinkModType": "16QAM",'
+            '"CQI": "9", "RI": "1", "numRbs": "8", "RSRP": "-70", "RSRQ": "-6"},'
+            '{"networkType": "8", "cellConnectionStatus": "1", "band": "7", "ARFCN": "536170",'
+            '"downBandWidth": "15000", "downFreq": "2680", "downlinkModType": "256QAM", "uplinkModType": "64QAM",'
+            '"CQI": "15", "RI": "2", "numRbs": "24", "RSRP": "-69", "RSRQ": "-11"},'
+            '{"networkType": "3", "cellConnectionStatus": "0", "band": "1", "ARFCN": "100",'
+            '"downBandWidth": "0", "downFreq": "0", "downlinkModType": "", "uplinkModType": "",'
+            '"CQI": "0", "RI": "0", "numRbs": "0", "RSRP": "0", "RSRQ": "0"}],'
+            '"operation":"go", "oid":"DEV2_LTE_SERVING_CELL_INFO","success":true}')
+
+        class TPLinkEXClientTest(TPLinkEXClient):
+            def _request(self, url, method='POST', data_str=None, encrypt=False):
+                if 'DEV2_LTE_SERVING_CELL_INFO' in data_str:
+                    return 200, DEV2_LTE_SERVING_CELL_INFO
+                raise ClientException()
+
+        client = TPLinkEXClientTest('', '')
+        cells = client.get_lte_serving_cells()
+
+        self.assertIsInstance(cells, list)
+        self.assertEqual(len(cells), 2)
+        self.assertEqual(cells[0]['networkType'], '3')
+        self.assertEqual(cells[0]['band'], '3')
+        self.assertEqual(cells[0]['RSRP'], '-70')
+        self.assertEqual(cells[1]['networkType'], '8')
+        self.assertEqual(cells[1]['band'], '7')
+        self.assertEqual(cells[1]['downlinkModType'], '256QAM')
+
+    def test_get_lte_serving_cells_empty(self) -> None:
+        DEV2_LTE_SERVING_CELL_INFO = (
+            '{"data":[{"networkType": "3", "cellConnectionStatus": "0", "band": "3", "ARFCN": "1300",'
+            '"downBandWidth": "0", "downFreq": "0", "downlinkModType": "", "uplinkModType": "",'
+            '"CQI": "0", "RI": "0", "numRbs": "0", "RSRP": "0", "RSRQ": "0"}],'
+            '"operation":"go", "oid":"DEV2_LTE_SERVING_CELL_INFO","success":true}')
+
+        class TPLinkEXClientTest(TPLinkEXClient):
+            def _request(self, url, method='POST', data_str=None, encrypt=False):
+                if 'DEV2_LTE_SERVING_CELL_INFO' in data_str:
+                    return 200, DEV2_LTE_SERVING_CELL_INFO
+                raise ClientException()
+
+        client = TPLinkEXClientTest('', '')
+        cells = client.get_lte_serving_cells()
+
+        self.assertIsInstance(cells, list)
+        self.assertEqual(len(cells), 0)
+
     def test_send_sms(self) -> None:
         check_url = ''
         check_data = ''

--- a/test/test_client_ex.py
+++ b/test/test_client_ex.py
@@ -16,6 +16,7 @@ from tplinkrouterc6u import (
     VPNStatus,
     VPN,
     SMS,
+    ServingCell,
 )
 
 
@@ -906,12 +907,18 @@ class TestTPLinkEXClient(TestCase):
 
         self.assertIsInstance(cells, list)
         self.assertEqual(len(cells), 2)
-        self.assertEqual(cells[0]['networkType'], '3')
-        self.assertEqual(cells[0]['band'], '3')
-        self.assertEqual(cells[0]['RSRP'], '-70')
-        self.assertEqual(cells[1]['networkType'], '8')
-        self.assertEqual(cells[1]['band'], '7')
-        self.assertEqual(cells[1]['downlinkModType'], '256QAM')
+        self.assertIsInstance(cells[0], ServingCell)
+        self.assertEqual(cells[0].network_type, 3)
+        self.assertEqual(cells[0].band, 3)
+        self.assertEqual(cells[0].arfcn, 1300)
+        self.assertEqual(cells[0].downlink_bandwidth, 20)
+        self.assertEqual(cells[0].downlink_frequency, 1815)
+        self.assertEqual(cells[0].rsrp, -70)
+        self.assertEqual(cells[0].rsrq, -6)
+        self.assertEqual(cells[1].network_type, 8)
+        self.assertEqual(cells[1].band, 7)
+        self.assertEqual(cells[1].downlink_bandwidth, 15)
+        self.assertEqual(cells[1].downlink_modulation, '256QAM')
 
     def test_get_lte_serving_cells_empty(self) -> None:
         DEV2_LTE_SERVING_CELL_INFO = (

--- a/test/test_client_mr.py
+++ b/test/test_client_mr.py
@@ -983,6 +983,66 @@ ispName=Name
 
         self.assertIsInstance(status, LTEStatus)
 
+    def test_get_lte_serving_cells(self) -> None:
+        response = '''[0,0,0,0,0,0]0
+cellConnectionStatus=1
+networkType=3
+band=3
+ARFCN=1300
+downBandWidth=20000
+downFreq=1830
+RSRP=-95
+RSRQ=-10
+[0,0,0,0,0,0]0
+cellConnectionStatus=1
+networkType=8
+band=78
+ARFCN=632628
+downBandWidth=100000
+downFreq=3600
+[0,0,0,0,0,0]0
+cellConnectionStatus=0
+networkType=3
+band=1
+ARFCN=100
+[error]0
+
+'''
+
+        class TPLinkMRClientTest(TPLinkMRClient):
+            def _request(self, url, method='POST', data_str=None, encrypt=False, is_login=False):
+                return 200, response
+
+        client = TPLinkMRClientTest('', '')
+        cells = client.get_lte_serving_cells()
+
+        self.assertIsInstance(cells, list)
+        self.assertEqual(len(cells), 2)
+        self.assertEqual(cells[0]['networkType'], '3')
+        self.assertEqual(cells[0]['band'], '3')
+        self.assertEqual(cells[0]['RSRP'], '-95')
+        self.assertEqual(cells[1]['networkType'], '8')
+        self.assertEqual(cells[1]['band'], '78')
+
+    def test_get_lte_serving_cells_empty(self) -> None:
+        response = '''[0,0,0,0,0,0]0
+cellConnectionStatus=0
+networkType=3
+band=3
+[error]0
+
+'''
+
+        class TPLinkMRClientTest(TPLinkMRClient):
+            def _request(self, url, method='POST', data_str=None, encrypt=False, is_login=False):
+                return 200, response
+
+        client = TPLinkMRClientTest('', '')
+        cells = client.get_lte_serving_cells()
+
+        self.assertIsInstance(cells, list)
+        self.assertEqual(len(cells), 0)
+
     def test_get_vpn_status(self) -> None:
         response = '''[0,0,0,0,0,0]0
 enable=1

--- a/test/test_client_mr.py
+++ b/test/test_client_mr.py
@@ -14,6 +14,7 @@ from tplinkrouterc6u import (
     ClientError,
     SMS,
     LTEStatus,
+    ServingCell,
     VPNStatus,
     VPN,
 )
@@ -1018,11 +1019,17 @@ ARFCN=100
 
         self.assertIsInstance(cells, list)
         self.assertEqual(len(cells), 2)
-        self.assertEqual(cells[0]['networkType'], '3')
-        self.assertEqual(cells[0]['band'], '3')
-        self.assertEqual(cells[0]['RSRP'], '-95')
-        self.assertEqual(cells[1]['networkType'], '8')
-        self.assertEqual(cells[1]['band'], '78')
+        self.assertIsInstance(cells[0], ServingCell)
+        self.assertEqual(cells[0].network_type, 3)
+        self.assertEqual(cells[0].band, 3)
+        self.assertEqual(cells[0].arfcn, 1300)
+        self.assertEqual(cells[0].downlink_bandwidth, 20)
+        self.assertEqual(cells[0].downlink_frequency, 1830)
+        self.assertEqual(cells[0].rsrp, -95)
+        self.assertEqual(cells[0].rsrq, -10)
+        self.assertEqual(cells[1].network_type, 8)
+        self.assertEqual(cells[1].band, 78)
+        self.assertEqual(cells[1].downlink_bandwidth, 100)
 
     def test_get_lte_serving_cells_empty(self) -> None:
         response = '''[0,0,0,0,0,0]0

--- a/tplinkrouterc6u/__init__.py
+++ b/tplinkrouterc6u/__init__.py
@@ -33,6 +33,7 @@ from tplinkrouterc6u.common.dataclass import (
     IPv4Status,
     SMS,
     LTEStatus,
+    ServingCell,
     VPNStatus,
     WifiStatus,
     VpnClientStatus,

--- a/tplinkrouterc6u/client/ex.py
+++ b/tplinkrouterc6u/client/ex.py
@@ -486,6 +486,15 @@ class TPLinkEXClient(TPLinkMRClientBase):
 
         self.req_act(acts)
 
+    def get_lte_serving_cells(self) -> list[dict]:
+        acts = [self.ActItem(self.ActItem.GL, 'DEV2_LTE_SERVING_CELL_INFO', attrs=[
+            'networkType', 'cellConnectionStatus', 'band', 'ARFCN', 'downBandWidth', 'downFreq',
+            'downlinkModType', 'uplinkModType', 'CQI', 'RI', 'numRbs', 'RSRP', 'RSRQ',
+        ])]
+        _, values = self.req_act(acts)
+        cells = values[0] if values else []
+        return [c for c in cells if c.get('cellConnectionStatus') == '1']
+
 
 # Class for EX series routers which supports AES cipher GCM mode
 class TPLinkEXClientGCM(TPLinkMRClientBaseGCM, TPLinkEXClient):

--- a/tplinkrouterc6u/client/ex.py
+++ b/tplinkrouterc6u/client/ex.py
@@ -14,6 +14,7 @@ from tplinkrouterc6u.common.dataclass import (
     IPv4Status,
     LTEStatus,
     SMS,
+    ServingCell,
     VPNStatus)
 from tplinkrouterc6u.common.exception import ClientException, ClientError
 from tplinkrouterc6u.client.mr import TPLinkMRClientBase, TPLinkMRClientBaseGCM
@@ -486,14 +487,39 @@ class TPLinkEXClient(TPLinkMRClientBase):
 
         self.req_act(acts)
 
-    def get_lte_serving_cells(self) -> list[dict]:
+    def get_lte_serving_cells(self) -> List[ServingCell]:
         acts = [self.ActItem(self.ActItem.GL, 'DEV2_LTE_SERVING_CELL_INFO', attrs=[
             'networkType', 'cellConnectionStatus', 'band', 'ARFCN', 'downBandWidth', 'downFreq',
             'downlinkModType', 'uplinkModType', 'CQI', 'RI', 'numRbs', 'RSRP', 'RSRQ',
         ])]
         _, values = self.req_act(acts)
-        cells = values[0] if values else []
-        return [c for c in cells if c.get('cellConnectionStatus') == '1']
+        raw_cells = values[0] if values else []
+
+        def clean_int(raw: str | None) -> int | None:
+            if raw is None or raw == '' or raw == '268435455':
+                return None
+            return int(raw)
+
+        cells = []
+        for c in raw_cells:
+            if c.get('cellConnectionStatus') != '1':
+                continue
+            bandwidth = clean_int(c.get('downBandWidth'))
+            cells.append(ServingCell(
+                network_type=int(c['networkType']),
+                band=int(c['band']),
+                arfcn=int(c['ARFCN']),
+                downlink_bandwidth=bandwidth // 1000 if bandwidth is not None else None,
+                downlink_frequency=clean_int(c.get('downFreq')),
+                downlink_modulation=c.get('downlinkModType') or None,
+                uplink_modulation=c.get('uplinkModType') or None,
+                cqi=clean_int(c.get('CQI')),
+                ri=clean_int(c.get('RI')),
+                resource_blocks=clean_int(c.get('numRbs')),
+                rsrp=clean_int(c.get('RSRP')),
+                rsrq=clean_int(c.get('RSRQ')),
+            ))
+        return cells
 
 
 # Class for EX series routers which supports AES cipher GCM mode

--- a/tplinkrouterc6u/client/mr.py
+++ b/tplinkrouterc6u/client/mr.py
@@ -824,6 +824,11 @@ class TPLinkMRClient(TPLinkMRClientBase):
 
         return status
 
+    def get_lte_serving_cells(self) -> list[dict]:
+        acts = [self.ActItem(self.ActItem.GL, 'DEV2_LTE_SERVING_CELL_INFO')]
+        _, values = self.req_act(acts)
+        return [c for c in self._to_list(values) if c.get('cellConnectionStatus') == '1']
+
 
 # Class for MR series routers which supports AES cipher GCM mode
 class TPLinkMRClientGCM(TPLinkMRClientBaseGCM, TPLinkMRClient):

--- a/tplinkrouterc6u/client/mr.py
+++ b/tplinkrouterc6u/client/mr.py
@@ -18,6 +18,7 @@ from tplinkrouterc6u.common.dataclass import (
     IPv4Status,
     SMS,
     LTEStatus,
+    ServingCell,
     VPNStatus,
 )
 from tplinkrouterc6u.common.exception import ClientException, ClientError
@@ -824,10 +825,35 @@ class TPLinkMRClient(TPLinkMRClientBase):
 
         return status
 
-    def get_lte_serving_cells(self) -> list[dict]:
+    def get_lte_serving_cells(self) -> List[ServingCell]:
         acts = [self.ActItem(self.ActItem.GL, 'DEV2_LTE_SERVING_CELL_INFO')]
         _, values = self.req_act(acts)
-        return [c for c in self._to_list(values) if c.get('cellConnectionStatus') == '1']
+
+        def clean_int(raw: str | None) -> int | None:
+            if raw is None or raw == '' or raw == '268435455':
+                return None
+            return int(raw)
+
+        cells = []
+        for c in self._to_list(values):
+            if c.get('cellConnectionStatus') != '1':
+                continue
+            bandwidth = clean_int(c.get('downBandWidth'))
+            cells.append(ServingCell(
+                network_type=int(c['networkType']),
+                band=int(c['band']),
+                arfcn=int(c['ARFCN']),
+                downlink_bandwidth=bandwidth // 1000 if bandwidth is not None else None,
+                downlink_frequency=clean_int(c.get('downFreq')),
+                downlink_modulation=c.get('downlinkModType') or None,
+                uplink_modulation=c.get('uplinkModType') or None,
+                cqi=clean_int(c.get('CQI')),
+                ri=clean_int(c.get('RI')),
+                resource_blocks=clean_int(c.get('numRbs')),
+                rsrp=clean_int(c.get('RSRP')),
+                rsrq=clean_int(c.get('RSRQ')),
+            ))
+        return cells
 
 
 # Class for MR series routers which supports AES cipher GCM mode

--- a/tplinkrouterc6u/common/dataclass.py
+++ b/tplinkrouterc6u/common/dataclass.py
@@ -265,6 +265,22 @@ class SMS:
 
 
 @dataclass
+class ServingCell:
+    network_type: int
+    band: int
+    arfcn: int
+    downlink_bandwidth: int | None = None
+    downlink_frequency: int | None = None
+    downlink_modulation: str | None = None
+    uplink_modulation: str | None = None
+    cqi: int | None = None
+    ri: int | None = None
+    resource_blocks: int | None = None
+    rsrp: int | None = None
+    rsrq: int | None = None
+
+
+@dataclass
 class LTEStatus:
     enable: int | None = None
     connect_status: int | None = None


### PR DESCRIPTION
## Summary
- Adds `get_lte_serving_cells()` to `TPLinkMRClient`, returning active LTE/NR
  serving cells (`cellConnectionStatus == '1'`) from `DEV2_LTE_SERVING_CELL_INFO`
- Follows the response-parsing pattern already used elsewhere in `mr.py`
  (`_to_list()` to normalize single-cell dict vs multi-cell list responses)
- Returns raw `list[dict]` rather than a dataclass, since the router's field
  set varies by network type and downstream consumers only need a handful of
  fields per cell type

## Motivation
Follow-up to feedback on AlexandrErohin/home-assistant-tplink-router#367 —
router communication logic (building the ActItem, parsing the response)
belongs in the client library rather than inline in the HA integration's
coordinator.

The integration side can then use this to expose per-cell-type sensors, reading:
- `networkType`, `band`, `ARFCN`, `downBandWidth`, `downFreq`,
  `downlinkModType`, `uplinkModType`, `CQI`, `RI`, `numRbs`
- `RSRP`, `RSRQ` (LTE/LTE+ only)

...separately for the NR cell, the LTE anchor cell, and the LTE+ (carrier
aggregation secondary) cell, plus a derived "active bands" summary
(e.g. `B8+N1`).

## Testing
- Unit tests added for multi-cell and empty-response cases
  (`test/test_client_mr.py`)
- Live-tested against a real NX200 router via a Home Assistant coordinator
  update, confirming NR/LTE band sensors populate correctly

## Test plan
- [x] Unit tests pass
- [x] Live verification against physical hardware