### PR TITLE
Add IPv6 status support for c6u client.

### DIFF
--- a/tplinkrouterc6u/__init__.py
+++ b/tplinkrouterc6u/__init__.py
@@ -31,6 +31,7 @@ from tplinkrouterc6u.common.dataclass import (
     IPv4Reservation,
     IPv4DHCPLease,
     IPv4Status,
+    IPv6Status,
     SMS,
     LTEStatus,
     VPNStatus,

--- a/tplinkrouterc6u/client/c6u.py
+++ b/tplinkrouterc6u/client/c6u.py
@@ -302,8 +302,8 @@ class TplinkBaseRouter(AbstractRouter, TplinkRequest):
         status._lan_ipv4_addr = get_ip(data['lan_ipv4_ipaddr']) if 'lan_ipv4_ipaddr' in data else None
         status._wan_ipv4_gateway = get_ip(data['wan_ipv4_gateway']) if 'wan_ipv4_gateway' in data else None
         status.wan_ipv4_uptime = data.get('wan_ipv4_uptime')
-        status.wan_ipv6_enable = self._str2bool(data.get('wan_ipv6_enable', ''))
-        status._wan_ipv6_addr = data.get('wan_ipv6_ip6addr', '::')
+        status.wan_ipv6_enabled = self._str2bool(data.get('wan_ipv6_enable', ''))
+        status._wan_ipv6_addr = get_ipv6(data.get('wan_ipv6_ip6addr', '::').split('/')[0])
         status.mem_usage = data.get('mem_usage')
         status.cpu_usage = data.get('cpu_usage')
         status.conn_type = data.get('conn_type')
@@ -419,16 +419,16 @@ class TplinkBaseRouter(AbstractRouter, TplinkRequest):
     def get_ipv6_status(self) -> IPv6Status:
         ipv6_status = IPv6Status()
         data = self.request('admin/network?form=status_ipv6&operation=read', 'operation=read')
-        ipv6_status.wan_ipv6_enable = self._str2bool(data.get('wan_ipv6_enable', ''))
+        ipv6_status.wan_ipv6_enabled = self._str2bool(data.get('wan_ipv6_enable', ''))
         ipv6_status._wan_ipv6_conntype = data.get('wan_ipv6_conntype', '')
-        ipv6_status._wan_ipv6_addr = data.get('wan_ipv6_ip6addr', '::')
+        ipv6_status._wan_ipv6_addr = get_ipv6(data.get('wan_ipv6_ip6addr', '::').split('/')[0])
         ipv6_status._wan_ipv6_gateway = get_ipv6(data.get('wan_ipv6_gateway', '::'))
         ipv6_status._wan_ipv6_pridns = get_ipv6(data.get('wan_ipv6_pridns', '::'))
         ipv6_status._wan_ipv6_snddns = get_ipv6(data.get('wan_ipv6_snddns', '::'))
 
         data = self.request('admin/network?form=wan_ipv6_dynamic&operation=read', 'operation=read')
-        ipv6_status._wan_ipv6_conn_status = data.get('conn_status', '::')
-        ipv6_status._wan_ipv6_prefix = get_ipv6(data.get('prefix', '::'))
+        ipv6_status._wan_ipv6_conn_status = data.get('conn_status', '')
+        ipv6_status._ipv6_site_prefix = get_ipv6(data.get('prefix', '::'))
 
         return ipv6_status
     

--- a/tplinkrouterc6u/client/c6u.py
+++ b/tplinkrouterc6u/client/c6u.py
@@ -6,7 +6,7 @@ from requests import post, Response
 from logging import Logger
 from urllib.parse import parse_qsl
 from json import dumps
-from tplinkrouterc6u.common.helper import get_ip, get_mac
+from tplinkrouterc6u.common.helper import get_ip, get_ipv6, get_mac
 from tplinkrouterc6u.common.encryption import EncryptionWrapper
 from tplinkrouterc6u.common.package_enum import Connection, VPN, VpnClientServerProtocol
 from tplinkrouterc6u.common.dataclass import (
@@ -16,6 +16,7 @@ from tplinkrouterc6u.common.dataclass import (
     IPv4Reservation,
     IPv4DHCPLease,
     IPv4Status,
+    IPv6Status,
     VPNStatus,
     VpnClientStatus,
     VpnClientServer,
@@ -299,9 +300,10 @@ class TplinkBaseRouter(AbstractRouter, TplinkRequest):
         status._lan_macaddr = get_mac(data['lan_macaddr'])
         status._wan_ipv4_addr = get_ip(data['wan_ipv4_ipaddr']) if 'wan_ipv4_ipaddr' in data else None
         status._lan_ipv4_addr = get_ip(data['lan_ipv4_ipaddr']) if 'lan_ipv4_ipaddr' in data else None
-        status._wan_ipv4_gateway = get_ip(
-            data['wan_ipv4_gateway']) if 'wan_ipv4_gateway' in data else None
+        status._wan_ipv4_gateway = get_ip(data['wan_ipv4_gateway']) if 'wan_ipv4_gateway' in data else None
         status.wan_ipv4_uptime = data.get('wan_ipv4_uptime')
+        status.wan_ipv6_enable = self._str2bool(data.get('wan_ipv6_enable', ''))
+        status._wan_ipv6_addr = data.get('wan_ipv6_ip6addr', '::')
         status.mem_usage = data.get('mem_usage')
         status.cpu_usage = data.get('cpu_usage')
         status.conn_type = data.get('conn_type')
@@ -414,6 +416,22 @@ class TplinkBaseRouter(AbstractRouter, TplinkRequest):
 
         return ipv4_status
 
+    def get_ipv6_status(self) -> IPv6Status:
+        ipv6_status = IPv6Status()
+        data = self.request('admin/network?form=status_ipv6&operation=read', 'operation=read')
+        ipv6_status.wan_ipv6_enable = self._str2bool(data.get('wan_ipv6_enable', ''))
+        ipv6_status._wan_ipv6_conntype = data.get('wan_ipv6_conntype', '')
+        ipv6_status._wan_ipv6_addr = data.get('wan_ipv6_ip6addr', '::')
+        ipv6_status._wan_ipv6_gateway = get_ipv6(data.get('wan_ipv6_gateway', '::'))
+        ipv6_status._wan_ipv6_pridns = get_ipv6(data.get('wan_ipv6_pridns', '::'))
+        ipv6_status._wan_ipv6_snddns = get_ipv6(data.get('wan_ipv6_snddns', '::'))
+
+        data = self.request('admin/network?form=wan_ipv6_dynamic&operation=read', 'operation=read')
+        ipv6_status._wan_ipv6_conn_status = data.get('conn_status', '::')
+        ipv6_status._wan_ipv6_prefix = get_ipv6(data.get('prefix', '::'))
+
+        return ipv6_status
+    
     @staticmethod
     def _as_list(data, envelope_key: str, what: str) -> list:
         """Return a list payload whether or not the router wrapped it.

--- a/tplinkrouterc6u/client/c80.py
+++ b/tplinkrouterc6u/client/c80.py
@@ -5,11 +5,11 @@ from collections import defaultdict
 import re
 import requests
 from requests import Session
-from tplinkrouterc6u.common.helper import get_ip, get_mac
+from tplinkrouterc6u.common.helper import get_ip, get_ipv6, get_mac
 from tplinkrouterc6u.common.package_enum import Connection
 from tplinkrouterc6u.common.exception import ClientException
 from tplinkrouterc6u.common.encryption import EncryptionWrapper
-from tplinkrouterc6u.common.dataclass import Firmware, Status, IPv4Status, IPv4Reservation
+from tplinkrouterc6u.common.dataclass import Firmware, Status, IPv4Status, IPv6Status, IPv4Reservation
 from tplinkrouterc6u.common.dataclass import IPv4DHCPLease, Device, VPNStatus
 from tplinkrouterc6u.client_abstract import AbstractRouter
 
@@ -40,6 +40,18 @@ class RouterConstants:
         '2': 'PPPoE',
         '3': 'L2TP',
         '4': 'PPTP'
+    }
+
+    CONNECTION_STATUS_MAP_IPV6 = {
+        '0': "Disabled",
+        '7': 'Disconnected',
+        '8': 'Connecting',
+        '9': 'Connected'
+    }
+
+    ADDR_TYPE_MAP_IPV6 = {
+        '0': "Unknown",
+        '1': 'DHCPv6'
     }
 
 
@@ -286,6 +298,45 @@ class TplinkC80Router(AbstractRouter):
 
         return mapped_leases
 
+    def get_ipv6_status(self) -> IPv6Status:
+        wan_ipv6_request = "45|1,0,0"
+        site_ipv6_request = "48|1,0,0"
+        all_requests = [
+            wan_ipv6_request, site_ipv6_request ]
+        request_text = '#'.join(all_requests)
+        body = self._encrypt_body(request_text)
+
+        response = self.request(2, 1, True, data=body)
+        response_text = self._decrypt_data(response.text)
+
+        matches = TplinkC80Router.DATA_REGEX.findall(response_text)
+
+        data_blocks = {match[0]: match[1].strip().split("\r\n") for match in matches}
+
+        network_info = {
+            'wan_ipv6_status': self._extract_value(data_blocks[wan_ipv6_request], "status "),
+            'wan_ipv6_getip': self._extract_value(data_blocks[wan_ipv6_request], "getIpWithDhcp "),
+            'wan_ipv6_ip': self._extract_value(data_blocks[wan_ipv6_request], "globalIp "),
+            'gateway_ipv6': self._extract_value(data_blocks[wan_ipv6_request], "gateway "),
+            'dns_1': self._extract_value(data_blocks[wan_ipv6_request], "dns 0 "),
+            'dns_2': self._extract_value(data_blocks[wan_ipv6_request], "dns 1 "),
+            'site_prefix': self._extract_value(data_blocks[site_ipv6_request], "prefixAddr "),
+            'site_prefix_len': self._extract_value(data_blocks[site_ipv6_request], "prefixLen "),
+        }
+
+        ipv6status = IPv6Status()
+        ipv6status.wan_ipv6_enabled = network_info['wan_ipv6_status'] != '0'
+        ipv6status._wan_ipv6_conn_status = RouterConstants.CONNECTION_STATUS_MAP_IPV6[network_info['wan_ipv6_status']]
+        ipv6status._wan_ipv6_addr_type = RouterConstants.ADDR_TYPE_MAP_IPV6[network_info['wan_ipv6_getip']]
+        ipv6status._wan_ipv6_addr = get_ipv6(network_info['wan_ipv6_ip'])
+        ipv6status._wan_ipv6_gateway = get_ipv6(network_info['gateway_ipv6'])
+        ipv6status._wan_ipv6_pridns = get_ipv6(network_info['dns_1'])
+        ipv6status._wan_ipv6_snddns = get_ipv6(network_info['dns_2'])
+        ipv6status._ipv6_site_prefix = get_ipv6(network_info['site_prefix'])
+        ipv6status._ipv6_site_prefix_length = network_info['site_prefix_len']
+
+        return ipv6status
+    
     def get_vpn_status(self) -> VPNStatus:
         body = self._encrypt_body("22|1,0,0")
 

--- a/tplinkrouterc6u/client/mr.py
+++ b/tplinkrouterc6u/client/mr.py
@@ -5,7 +5,7 @@ from urllib.parse import quote
 from requests import Session, Response
 from datetime import timedelta, datetime
 from logging import Logger
-from tplinkrouterc6u.common.helper import get_ip, get_mac, get_value
+from tplinkrouterc6u.common.helper import get_ip, get_ipv6, get_mac, get_value
 from tplinkrouterc6u.common.encryption import EncryptionWrapperMR, EncryptionWrapperMRGCM, EncryptionWrapperMRECC
 from json import loads as json_loads
 from tplinkrouterc6u.common.package_enum import Connection, VPN
@@ -330,6 +330,8 @@ class TPLinkMRClientBase(AbstractRouter):
             ipv6_dns = item.get('X_TP_IPv6DNSServers', '').split(',')
             ipv6_status._wan_ipv6_pridns = get_ipv6(ipv6_dns[0] if len(ipv6_dns) > 0 else '::')
             ipv6_status._wan_ipv6_snddns = get_ipv6(ipv6_dns[1] if len(ipv6_dns) > 0 else '::')
+            ipv6_status._ipv6_site_prefix = get_ipv6(item.get('X_TP_SitePrefix', '::'))
+            ipv6_status._ipv6_site_prefix_length = item.get('X_TP_SitePrefixLength')
 
         return ipv6_status
     

--- a/tplinkrouterc6u/client/mr.py
+++ b/tplinkrouterc6u/client/mr.py
@@ -16,6 +16,7 @@ from tplinkrouterc6u.common.dataclass import (
     IPv4Reservation,
     IPv4DHCPLease,
     IPv4Status,
+    IPv6Status,
     SMS,
     LTEStatus,
     VPNStatus,
@@ -313,6 +314,25 @@ class TPLinkMRClientBase(AbstractRouter):
 
         return ipv4_status
 
+    def get_ipv6_status(self) -> IPv6Status:
+        acts = [
+           self.ActItem(self.ActItem.GS, 'WAN_IP_CONN')
+        ]
+        _, values = self.req_act(acts)
+
+        ipv6_status = IPv6Status()
+
+        for item in self._to_list(values):
+            if int(item.get('enable', '0')) == 0:
+                continue
+            ipv6_status._wan_ipv6_addr = get_ipv6(item.get('X_TP_ExternalIPv6Address', '::'))
+            ipv6_status._wan_ipv6_gateway = get_ipv6(item.get('X_TP_DefaultIPv6Gateway', '::'))
+            ipv6_dns = item.get('X_TP_IPv6DNSServers', '').split(',')
+            ipv6_status._wan_ipv6_pridns = get_ipv6(ipv6_dns[0] if len(ipv6_dns) > 0 else '::')
+            ipv6_status._wan_ipv6_snddns = get_ipv6(ipv6_dns[1] if len(ipv6_dns) > 0 else '::')
+
+        return ipv6_status
+    
     def set_wifi(self, wifi: Connection, enable: bool) -> None:
         acts = [
             self.ActItem(

--- a/tplinkrouterc6u/common/dataclass.py
+++ b/tplinkrouterc6u/common/dataclass.py
@@ -260,7 +260,7 @@ class IPv4Status:
     def lan_ipv4_netmask_address(self):
         return self._lan_ipv4_netmask
 
-    @dataclass
+@dataclass
 class IPv6Status:
     _wan_ipv6_conn_status: str = ""
     _wan_ipv6_conntype: str = ""

--- a/tplinkrouterc6u/common/dataclass.py
+++ b/tplinkrouterc6u/common/dataclass.py
@@ -54,7 +54,7 @@ class Status:
     _wan_ipv4_addr: IPv4Address | None = None
     _lan_ipv4_addr: IPv4Address | None = None
     _wan_ipv4_gateway: IPv4Address | None = None
-    wan_ipv6_enable: bool | None = None
+    wan_ipv6_enabled: bool | None = None
     _wan_ipv6_addr: IPv6Address | None = None
     wired_total: int = 0
     wifi_clients_total: int = 0
@@ -262,15 +262,16 @@ class IPv4Status:
 
 @dataclass
 class IPv6Status:
+    wan_ipv6_enabled: bool | None = None
     _wan_ipv6_conn_status: str = ""
     _wan_ipv6_conntype: str = ""
     _wan_ipv6_addr_type: str = ""
     _wan_ipv6_addr: IPv6Address | None = None
     _wan_ipv6_gateway: IPv6Address | None = None
-    _wan_ipv6_prefix: IPv6Address | None = None
-    _wan_ipv6_pridns_address: IPv6Address | None = None
-    _wan_ipv6_secdns_address: IPv6Address | None = None
-    wan_ipv6_enable: bool | None = None
+    _wan_ipv6_pridns: IPv6Address | None = None
+    _wan_ipv6_snddns: IPv6Address | None = None
+    _ipv6_site_prefix: IPv6Address | None = None
+    _ipv6_site_prefix_length: str = ""
     
     @property
     def wan_ipv6_conn_status(self):
@@ -288,14 +289,17 @@ class IPv6Status:
     def wan_ipv6_gateway(self):
         return str(self._wan_ipv6_gateway) if self._wan_ipv6_gateway else None
     @property
-    def wan_ipv6_prefix(self):
-        return str(self._wan_ipv6_prefix)
-    @property
     def wan_ipv6_pridns(self):
         return self._wan_ipv6_pridns
     @property
     def wan_ipv6_snddns(self):
         return self._wan_ipv6_snddns
+    @property
+    def ipv6_site_prefix(self):
+        return str(self._ipv6_site_prefix)
+    @property
+    def ipv6_site_prefix_length(self):
+        return str(self._ipv6_site_prefix_length)
 
 
 @dataclass

--- a/tplinkrouterc6u/common/dataclass.py
+++ b/tplinkrouterc6u/common/dataclass.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from macaddress import EUI48
-from ipaddress import IPv4Address
+from ipaddress import IPv4Address, IPv6Address
 from dataclasses import dataclass, field
 from datetime import datetime
 from tplinkrouterc6u.common.package_enum import Connection, VpnClientServerProtocol
@@ -54,6 +54,8 @@ class Status:
     _wan_ipv4_addr: IPv4Address | None = None
     _lan_ipv4_addr: IPv4Address | None = None
     _wan_ipv4_gateway: IPv4Address | None = None
+    wan_ipv6_enable: bool | None = None
+    _wan_ipv6_addr: IPv6Address | None = None
     wired_total: int = 0
     wifi_clients_total: int = 0
     guest_clients_total: int = 0
@@ -113,6 +115,10 @@ class Status:
     @property
     def wan_ipv4_gateway_address(self) -> IPv4Address | None:
         return self._wan_ipv4_gateway
+
+    @property
+    def wan_ipv6_addr(self) -> str | None:
+        return str(self._wan_ipv6_addr) if self._wan_ipv6_addr else None
 
 
 @dataclass
@@ -253,6 +259,43 @@ class IPv4Status:
     @property
     def lan_ipv4_netmask_address(self):
         return self._lan_ipv4_netmask
+
+    @dataclass
+class IPv6Status:
+    _wan_ipv6_conn_status: str = ""
+    _wan_ipv6_conntype: str = ""
+    _wan_ipv6_addr_type: str = ""
+    _wan_ipv6_addr: IPv6Address | None = None
+    _wan_ipv6_gateway: IPv6Address | None = None
+    _wan_ipv6_prefix: IPv6Address | None = None
+    _wan_ipv6_pridns_address: IPv6Address | None = None
+    _wan_ipv6_secdns_address: IPv6Address | None = None
+    wan_ipv6_enable: bool | None = None
+    
+    @property
+    def wan_ipv6_conn_status(self):
+        return str(self._wan_ipv6_conn_status) if self._wan_ipv6_conn_status else None
+    @property
+    def wan_ipv6_conntype(self):
+        return str(self._wan_ipv6_conntype) if self._wan_ipv6_conntype else None
+    @property
+    def wan_ipv6_addr_type(self):
+        return str(self._wan_ipv6_addr_type) if self._wan_ipv6_addr_type else None
+    @property
+    def wan_ipv6_addr(self):
+        return str(self._wan_ipv6_addr) if self._wan_ipv6_addr else None
+    @property
+    def wan_ipv6_gateway(self):
+        return str(self._wan_ipv6_gateway) if self._wan_ipv6_gateway else None
+    @property
+    def wan_ipv6_prefix(self):
+        return str(self._wan_ipv6_prefix)
+    @property
+    def wan_ipv6_pridns(self):
+        return self._wan_ipv6_pridns
+    @property
+    def wan_ipv6_snddns(self):
+        return self._wan_ipv6_snddns
 
 
 @dataclass

--- a/tplinkrouterc6u/common/helper.py
+++ b/tplinkrouterc6u/common/helper.py
@@ -1,4 +1,4 @@
-from ipaddress import IPv4Address
+from ipaddress import IPv4Address, IPv6Address
 from macaddress import EUI48
 
 
@@ -7,6 +7,13 @@ def get_ip(ip: str) -> IPv4Address:
         return IPv4Address(ip)
     except Exception:
         return IPv4Address('0.0.0.0')
+
+
+def get_ipv6(ip: str) -> IPv6Address:
+    try:
+        return IPv6Address(ip)
+    except Exception:
+        return IPv6Address('::')
 
 
 def get_mac(mac: str) -> EUI48:


### PR DESCRIPTION
This adds IPv6 support to get_status in c6u client, and diagnostics (get_ipv6_status) to c6u, mr, and c80 clients.

Two new parameters are obtained from existing status query in c6u client.  (Later I will raise a PR for the main integration, to add sensor/s for display of new info).

The changes have been tested using AX55 f/w 1.5.10 and 1.5.12. The get_ipv6_status diagnostic in MR client tested with VR1600v, and in c80 client tested with C24.

I am also working on a strategy for inclusion of IPv6 in MR client.  I have discovered that if no parameters are specified on the WAN_IP_CONN request, my test router returns all parameters.  As I don't know whether other MR client routers do the same, there is an alternative, which is to add the IPv6 request at the end of actions.  I am continuing to test these ideas.