### PR TITLE
fix: correct OAEP signature chunk size in TplinkRouterSG

### DIFF
--- a/test/test_client_sg.py
+++ b/test/test_client_sg.py
@@ -26,6 +26,40 @@ class TestTplinkRouterSGUnit(TestCase):
         client = TplinkRouterSG('http://192.168.0.1', long_password)
         self.assertFalse(client.supports())
 
+    def test_build_login_signature_real_key_size(self) -> None:
+        """Regression test for #171/#185.
+
+        The auth ("nn"/"ee") key TP-Link actually serves is 512-bit (128 hex
+        chars). SIGNATURE_OFFSET (53) is sized for PKCS1v1.5's 11-byte
+        overhead; under OAEP's much larger overhead (2*hLen+2 = 42 bytes for
+        the SHA-1 pycryptodome defaults to) a 53-byte chunk does not fit in a
+        single 512-bit block, and PKCS1_OAEP.encrypt() raises
+        "Plaintext is too long.". Every previous test in this file mocks
+        either `request()` (via TestTPLinkClient) or `_build_login_signature`
+        itself, so this real, unmocked call is the only thing that exercises
+        the actual RSA-OAEP chunking against a realistically-sized key.
+        """
+        client = TplinkRouterSG('http://192.168.0.1', 'testpassword')
+        client._aes_key = '1234567890123456'
+        client._aes_iv = '6543210987654321'
+        client._hash = sha256(b'admintestpassword').hexdigest()
+        client._seq = 555111222
+        # A real 512-bit auth key as served by an Archer AX12 on SG CLS L1
+        # STAGE2 firmware (public key only -- no private counterpart needed
+        # to exercise the encryption path).
+        client._nn = (
+            'ca8f1711cc27576fb0dae0d7df1b6a90465e8ea31ccf46b0004f4c60f6617df'
+            '8fa147502e45353b4d3f8ad38cb9aee9a77d33973ce3d7d681bc2fb0ae242e631'
+        )
+        client._ee = '010001'
+
+        sign = client._build_login_signature(data_len=32)
+
+        # Must not raise ValueError("Plaintext is too long."), and the
+        # result must be a whole number of 512-bit (128 hex char) RSA blocks.
+        self.assertGreater(len(sign), 0)
+        self.assertEqual(len(sign) % 128, 0)
+
     @patch('tplinkrouterc6u.client.sg.post')
     def test_check_sg_certification_match(self, mock_post: Mock) -> None:
         response = Mock()

--- a/tplinkrouterc6u/client/sg.py
+++ b/tplinkrouterc6u/client/sg.py
@@ -166,10 +166,15 @@ class TplinkRouterSG(TplinkBaseRouter):
         sign = ''
         # OAEP overhead (SHA-1, pycryptodome's default hash for PKCS1_OAEP.new())
         # is 2*hLen+2 = 42 bytes, unlike PKCS1v1.5's 11-byte overhead. The fixed
-        # SIGNATURE_OFFSET (53, sized for PKCS1v1.5) overflows the 512-bit auth
-        # key used here, raising "Plaintext is too long." on every login attempt.
+        # SIGNATURE_OFFSET (53, sized for PKCS1v1.5) overflows small auth keys
+        # (e.g. 512-bit, max OAEP payload 22 bytes), raising "Plaintext is too
+        # long." on every login attempt. Cap at SIGNATURE_OFFSET rather than
+        # always using the OAEP-safe max: for keys large enough that 53 never
+        # overflowed (e.g. 1024-bit, max payload 86 bytes), this keeps the
+        # exact legacy chunking unchanged, in case some firmware's signature
+        # parsing is sensitive to the resulting block size/count.
         rsa_byte_len = len(self._nn) // 2
-        oaep_step = rsa_byte_len - 2 * 20 - 2
+        oaep_step = min(SIGNATURE_OFFSET, rsa_byte_len - 2 * 20 - 2)
         for i in range(0, len(sign_str), oaep_step):
             chunk = sign_str[i:i + oaep_step]
             sign += self._rsa_oaep_encrypt(chunk, self._nn, self._ee)

--- a/tplinkrouterc6u/client/sg.py
+++ b/tplinkrouterc6u/client/sg.py
@@ -164,8 +164,14 @@ class TplinkRouterSG(TplinkBaseRouter):
         sign_str = '{}&h={}&s={}'.format(
             self._get_aes_formatted_key(), self._hash, self._seq + data_len)
         sign = ''
-        for i in range(0, len(sign_str), SIGNATURE_OFFSET):
-            chunk = sign_str[i:i + SIGNATURE_OFFSET]
+        # OAEP overhead (SHA-1, pycryptodome's default hash for PKCS1_OAEP.new())
+        # is 2*hLen+2 = 42 bytes, unlike PKCS1v1.5's 11-byte overhead. The fixed
+        # SIGNATURE_OFFSET (53, sized for PKCS1v1.5) overflows the 512-bit auth
+        # key used here, raising "Plaintext is too long." on every login attempt.
+        rsa_byte_len = len(self._nn) // 2
+        oaep_step = rsa_byte_len - 2 * 20 - 2
+        for i in range(0, len(sign_str), oaep_step):
+            chunk = sign_str[i:i + oaep_step]
             sign += self._rsa_oaep_encrypt(chunk, self._nn, self._ee)
         return sign
 


### PR DESCRIPTION
## What's broken

`_build_login_signature()` in `TplinkRouterSG` splits the signature string
into fixed 53-byte chunks before RSA-OAEP-encrypting each one. 53 bytes is
sized for PKCS1v1.5's 11-byte overhead — OAEP's overhead
(`2*hLen+2` = 42 bytes with pycryptodome's default SHA-1) is much larger, so
any chunk over `modulus_len-42` bytes overflows `PKCS1_OAEP.encrypt()` with
`ValueError: Plaintext is too long.` on the 512-bit auth key used for the
login signature.

The practical effect: `authorize()` always raises, so `supports()` always
returns `False`, so `TplinkRouterSG` can never actually be selected by
`TplinkRouterProvider.get_client()` or used at all — every SG/CE_RED
certified router falls through to the legacy `TplinkRouter` class, which
uses the wrong hash algorithm and padding scheme for these devices and
fails with a `403`/empty-body response on every login attempt.

## Fix

Compute the OAEP chunk size from the auth key's modulus length instead of
reusing the PKCS1v1.5-sized constant.

## Testing

Verified end-to-end against a real Archer AX12 v1.0 running firmware
certified `SG CLS L1 STAGE2` (previously failing with
`Cannot authorize! Error - Expecting value: line 1 column 1 (char 0)`):

- `TplinkRouterSG(...).supports()` → `True`
- `authorize()` → succeeds, returns a valid `stok`
- `get_firmware()` → real firmware info (`Archer AX12 v1.0`, `1.3.2 Build 20260324...`)
- `get_status()` → real WAN IP
- `logout()` → clean

Related: #171