### PR TITLE
Add IPv6 to get_status in MR client.

### DIFF
--- a/tplinkrouterc6u/client/mr.py
+++ b/tplinkrouterc6u/client/mr.py
@@ -169,6 +169,8 @@ class TPLinkMRClientBase(AbstractRouter):
                 'X_TP_TotalPacketsSent',
                 'X_TP_TotalPacketsReceived',
             ]),
+            self.ActItem(self.ActItem.GS, 'WAN_IP_CONN',
+                         attrs=['enable', 'X_TP_IPv6Enabled', 'X_TP_IPv6ConnStatus', 'X_TP_ExternalIPv6Address']),
         ]
         _, values = self.req_act(acts)
 
@@ -226,6 +228,13 @@ class TPLinkMRClientBase(AbstractRouter):
                     '')
             devices[val['associatedDeviceMACAddress']].packets_sent = int(val['X_TP_TotalPacketsSent'])
             devices[val['associatedDeviceMACAddress']].packets_received = int(val['X_TP_TotalPacketsReceived'])
+
+        for item in self._to_list(values.get('6')):
+            if int(item['enable']) == 0 and values.get('6').__class__ == list:
+                continue
+            status.wan_ipv6_enabled = item.get('X_TP_IPv6Enabled') == '1'
+            status._wan_ipv6_conn_status = item.get('X_TP_IPv6ConnStatus', '')
+            status._wan_ipv6_addr = get_ipv6(item.get('X_TP_ExternalIPv6Address', '::'))
 
         try:
             stat_acts = [self.ActItem(self.ActItem.GL, 'STAT_ENTRY')]


### PR DESCRIPTION
This adds IPv6 support to get_status in MR client.
A new WAN_IP_CONN request is added at the end of the list of actions, to obtain IPv6 specifics.
By placing it last, it shouldn't affect responses earlier in the list, for routers without IPv6 support.  This has been tested in principle by specifying an invalid parameter name - there was no impact on responses to actions earlier in the list, and the router continued to respond to data fetches.

Testing was done with VR1600v v1, f/w 2.1.0, and VR400 v3, f/w 1.6.0.

Requests and responses for the test cases:
[VR400 v3 - test invalid parm.txt](https://github.com/user-attachments/files/30852204/VR400.v3.-.test.invalid.parm.txt)
[VR400 v3 - IPv6 disabled.txt](https://github.com/user-attachments/files/30852209/VR400.v3.-.IPv6.disabled.txt)
[VR400 v3 - IPv6 enabled.txt](https://github.com/user-attachments/files/30852214/VR400.v3.-.IPv6.enabled.txt)
[VR1600v - IPv6 enabled.txt](https://github.com/user-attachments/files/30852218/VR1600v.-.IPv6.enabled.txt)
