### PR TITLE
Add EasyMesh requests to c6u client.

### DIFF
--- a/tplinkrouterc6u/client/c6u.py
+++ b/tplinkrouterc6u/client/c6u.py
@@ -471,6 +471,22 @@ class TplinkBaseRouter(AbstractRouter, TplinkRequest):
             # WiFi might be disabled on the router, skip wireless statistics
             pass
 
+        try:
+            easymesh_node_list = self.request('admin/easymesh_network?form=get_mesh_device_list_all&operation=read', 'operation=read')
+            for ap in easymesh_node_list:
+                # 'sclient' is mesh main or satellite, 'nclient' is a network device
+                sclient_detail = self.request('admin/easymesh_network?form=mesh_sclient_detail&operation=read&mac='+ap['mac'], 'operation=read&mac='+ap['mac'])
+                for nclient in sclient_detail['mesh_nclient_list']:
+                    if ap['role'] == 'satellite_router':
+                        devices[nclient['mac']].ap_name = ap['name']
+                        devices[nclient['mac']].signal = nclient['signal_strength']
+                    else:
+                        # prefix * helps sorting main node for display
+                        devices[nclient['mac']].ap_name = '*'+ap['name']
+        except Exception:
+            # skip if router doesn't support EasyMesh
+            pass 
+
         status.devices = list(devices.values())
         status.clients_total = (status.wired_total + status.wifi_clients_total + status.guest_clients_total
                                 + (status.iot_clients_total or 0))

--- a/tplinkrouterc6u/client/mr.py
+++ b/tplinkrouterc6u/client/mr.py
@@ -169,6 +169,8 @@ class TPLinkMRClientBase(AbstractRouter):
                 'X_TP_TotalPacketsSent',
                 'X_TP_TotalPacketsReceived',
             ]),
+            self.ActItem(self.ActItem.GS, 'WAN_IP_CONN',
+                         attrs=['enable', 'X_TP_IPv6Enabled', 'X_TP_IPv6ConnStatus', 'X_TP_ExternalIPv6Address']),
         ]
         _, values = self.req_act(acts)
 
@@ -226,6 +228,13 @@ class TPLinkMRClientBase(AbstractRouter):
                     '')
             devices[val['associatedDeviceMACAddress']].packets_sent = int(val['X_TP_TotalPacketsSent'])
             devices[val['associatedDeviceMACAddress']].packets_received = int(val['X_TP_TotalPacketsReceived'])
+
+        for item in self._to_list(values.get('6')):
+            if int(item['enable']) == 0 and values.get('6').__class__ == list:
+                continue
+            status.wan_ipv6_enabled = item.get('X_TP_IPv6Enabled') == '1'
+            status._wan_ipv6_conn_status = item.get('X_TP_IPv6ConnStatus', '')
+            status._wan_ipv6_addr = get_ipv6(item.get('X_TP_ExternalIPv6Address', '::'))
 
         try:
             stat_acts = [self.ActItem(self.ActItem.GL, 'STAT_ENTRY')]

--- a/tplinkrouterc6u/common/dataclass.py
+++ b/tplinkrouterc6u/common/dataclass.py
@@ -21,6 +21,7 @@ class Device:
     _macaddr: EUI48
     _ipaddr: IPv4Address
     hostname: str
+    ap_name: str | None = None
     packets_sent: int | None = None
     packets_received: int | None = None
     down_speed: int | None = None

--- a/tplinkrouterc6u/common/dataclass.py
+++ b/tplinkrouterc6u/common/dataclass.py
@@ -21,7 +21,6 @@ class Device:
     _macaddr: EUI48
     _ipaddr: IPv4Address
     hostname: str
-    ap_name: str | None = None
     packets_sent: int | None = None
     packets_received: int | None = None
     down_speed: int | None = None


### PR DESCRIPTION
This adds EasyMesh requests to get_status in c6u client, and provides AP association information for wifi devices.

For each wifi device, the AP name is stored as an extra attribute in the device tracker object.
To simplify sorting in a dashboard display, I've prefixed the main node name with an asterisk, so the devices attached to that node can be listed as a group, before the groups of devices on each satellite node. This was a simple way of differentiating between main and satellite without adding another attribute field.

It was found during testing with AX55 that the existing 'signal' value for devices connected to a satellite node is sometimes the value at the satellite node, but at other times it appears to be left over from when it was on the main node.  The code I've written places the value provided by the satellite node into the existing 'signal' attribute.

Below is a small piece of the HA dashboard display, created with jinja templating to select and sort attributes.
The columns are device name, ap name, signal level, and last octet of ip address.

<img width="484" height="199" alt="easymesh-dashboard-clip" src="https://github.com/user-attachments/assets/eb6e0925-b6c9-4558-9032-8fe735ec1928" />

Later, if the changes are acceptable, I will submit a PR on the main integration for an extra device attribute to contain the ap_name.
