### PR TITLE
fix(sg): VPN client status broken on BE-series routers (missing header + WireGuard)

### DIFF
--- a/test/test_client_sg.py
+++ b/test/test_client_sg.py
@@ -3,7 +3,12 @@ from hashlib import sha256
 from unittest import main, TestCase
 from unittest.mock import patch, Mock
 
-from tplinkrouterc6u import TplinkRouterSG, ClientException
+from tplinkrouterc6u import (
+    TplinkRouterSG,
+    ClientException,
+    VpnClientServer,
+    VpnClientServerProtocol,
+)
 from test_client_c6u import TestTPLinkClient
 
 
@@ -305,6 +310,35 @@ class TestTplinkRouterSGUnit(TestCase):
         call_kwargs = mock_post.call_args
         headers = call_kwargs[1]['headers']
         self.assertEqual(headers.get('Content-Type'), 'application/x-www-form-urlencoded')
+
+
+class TestTplinkRouterSGVpnClientStatus(TestCase):
+    """Regression tests for WireGuard support in the VPN client server parser."""
+
+    def test_get_vpn_client_status_wireguard_server(self) -> None:
+        class TPLinkRouterTest(TplinkRouterSG):
+            def request(self, path, data, ignore_response=False, ignore_errors=False):
+                if 'admin/vpn?form=enable' in path:
+                    return {'enable': 'on'}
+                if 'admin/vpn?form=server' in path:
+                    return [
+                        {'.name': 'cfg1a2b3c', 'key': 'key-wg', 'type': 'wireguard',
+                         'enable': 'on', 'des': 'WG Server', 'status': 'connected'},
+                    ]
+                if 'admin/vpn?form=vpn_user_list' in path:
+                    return []
+                raise ClientException()
+
+        client = TPLinkRouterTest('http://192.168.0.1', 'testpassword')
+        result = client.get_vpn_client_status()
+
+        self.assertEqual(len(result.servers), 1)
+        server = result.servers[0]
+        self.assertIsInstance(server, VpnClientServer)
+        self.assertEqual(server.protocol, VpnClientServerProtocol.WIREGUARD)
+        self.assertEqual(server.id, 'key-wg')
+        self.assertTrue(server.active)
+        self.assertEqual(server.status, 'connected')
 
 
 if __name__ == '__main__':

--- a/test/test_client_sg.py
+++ b/test/test_client_sg.py
@@ -276,6 +276,36 @@ class TestTplinkRouterSGUnit(TestCase):
         headers = call_kwargs[1]['headers']
         self.assertEqual(headers.get('Content-Type'), 'application/x-www-form-urlencoded')
 
+    @patch('tplinkrouterc6u.client.sg.post')
+    def test_request_read_content_type_header(self, mock_post: Mock) -> None:
+        """Regression test: BE3600 rejects READ requests missing Content-Type.
+
+        The write branch always set Content-Type, but the read (non-write)
+        branch left it unset, relying on requests' default. The BE3600
+        firmware requires it explicitly on every request, so it must be set
+        on reads too.
+        """
+        client = TplinkRouterSG('http://192.168.0.1', 'testpassword')
+        client._logged = True
+        client._stok = 'test_stok'
+        client._sysauth = 'test_sysauth'
+        client._aes_key = '1234567890123456'
+        client._aes_iv = '6543210987654321'
+        client._hash = 'fakehash'
+        client._seq = 100
+
+        response = Mock()
+        decrypted_data = json.dumps({'success': True, 'data': {'key': 'value'}})
+        response.json.return_value = {'data': 'encrypted'}
+        mock_post.return_value = response
+
+        with patch.object(client, '_aes_decrypt', return_value=decrypted_data):
+            client.request('admin/status?form=all', 'operation=read')
+
+        call_kwargs = mock_post.call_args
+        headers = call_kwargs[1]['headers']
+        self.assertEqual(headers.get('Content-Type'), 'application/x-www-form-urlencoded')
+
 
 if __name__ == '__main__':
     main()

--- a/tplinkrouterc6u/client/sg.py
+++ b/tplinkrouterc6u/client/sg.py
@@ -273,6 +273,7 @@ class TplinkRouterSG(TplinkBaseRouter):
             hdrs['Content-Type'] = 'application/x-www-form-urlencoded'
         else:
             body = 'sign={}&data={}'.format(sign, quote(encrypted_data))
+            hdrs['Content-Type'] = 'application/x-www-form-urlencoded'
 
         response = post(
             url, data=body, headers=hdrs,

--- a/tplinkrouterc6u/common/package_enum.py
+++ b/tplinkrouterc6u/common/package_enum.py
@@ -61,3 +61,4 @@ class VpnClientServerProtocol(Enum):
     OPEN_VPN = 'openvpn'
     PPTP = 'pptp'
     L2TP_IPSEC = 'l2tp'
+    WIREGUARD = 'wireguard'


### PR DESCRIPTION
## Problem

On my Archer BE3600 (`TplinkRouterSG` client), `get_vpn_client_status()` always
failed, so the VPN client entities never showed up.

Two separate bugs caused this:

1. **Missing `Content-Type` header on read requests.** `request()` only set
   `Content-Type: application/x-www-form-urlencoded` for write operations.
   The BE-series firmware requires it on every request, so read-only calls
   like `admin/vpn?form=enable` / `form=server` / `form=vpn_user_list` were
   rejected by the router's Lua dispatcher.
2. **WireGuard wasn't a recognized VPN protocol.** `VpnClientServerProtocol`
   only had `openvpn`/`pptp`/`l2tp`, but current firmware offers WireGuard
   in the VPN Client menu. Since the parser raises on any unrecognized
   `type`, a single WireGuard profile broke the whole status call.

## Fix

- Set the `Content-Type` header on the read branch of `request()` too.
- Add `WIREGUARD = 'wireguard'` to `VpnClientServerProtocol`.

Added regression tests in `test/test_client_sg.py` for both: one asserting
the header is present on reads, one feeding a WireGuard server dict through
`get_vpn_client_status()`.

Two independent fixes, kept as two commits for easier review.
