### PR TITLE
feat: add TP-Link Deco E4R support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ from tplinkrouterc6u import (
     TPLinkRClient, # For routers like TL-R470GP-AC
     TPLinkXDRClient,
     TPLinkDecoClient,
+    TplinkDecoE4RRouter,
     TPLinkEAP115Client,
     TPLinkCPE210Client,
     TPLinkSG108EClient,
@@ -461,6 +462,7 @@ Not all fields are filled by every client:
 - CPE210 v2.0
 - CPE220 v3.0
 - Deco BE25 1.0
+- Deco E4R
 - Deco M4 2.0
 - Deco M4R 2.0
 - Deco M5 v3

--- a/test/test_client_deco_e4r.py
+++ b/test/test_client_deco_e4r.py
@@ -1,0 +1,222 @@
+from base64 import b64encode
+from hashlib import md5
+from json import dumps
+from unittest import main, TestCase
+from urllib import parse
+from ipaddress import IPv4Address
+from macaddress import EUI48
+from tplinkrouterc6u.common.dataclass import Firmware, Status, Device
+from tplinkrouterc6u import Connection, ClientException
+from tplinkrouterc6u.client.deco_e4r import TplinkDecoE4RRouter
+from tplinkrouterc6u.provider import TplinkRouterProvider
+
+
+# A synthetic RSA-512 public modulus (borrowed from the RE330 test fixtures) so the
+# handshake's RSA operations succeed without touching a real device.
+TEST_NN = ('BC97577E65233B3E1137C61091D64176C334E52AD78FFBDDABC826B685435E'
+           '9D3DE83FE70C2AC62D6B13BD8EADA10B5623F9354DA0E99636A4F5519CA2DC2DC3')
+TEST_SEQ = '12345656'
+
+# Synthetic challenge: 00007 header, a 32-char token key, then the alphabet blob.
+CHALLENGE_LINE3 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ012345'
+CHALLENGE_LINE4 = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ+/'
+CHALLENGE = ('00007\r\n00004\r\n00000\r\n{}\r\n{}\r\n00000\r\n'.format(CHALLENGE_LINE3, CHALLENGE_LINE4))
+
+
+class ResponseMock:
+    def __init__(self, text, status_code=200):
+        self.text = text
+        self.status_code = status_code
+
+
+class SessionMock:
+    """Stands in for requests.Session for the JSON data layer. Encrypts each
+    fixture with the client's live AES cipher so the real decrypt path runs."""
+
+    def __init__(self, client, fixtures):
+        self._client = client
+        self._fixtures = fixtures
+        self.last_url = None
+        self.last_body = None
+
+    def post(self, url, data=None, headers=None, timeout=None, verify=None):
+        self.last_url = url
+        self.last_body = data
+        for key, payload in self._fixtures.items():
+            if key in url:
+                return ResponseMock(self._client._encryption.aes_encrypt(payload))
+        raise AssertionError('Unexpected data request URL: {}'.format(url))
+
+
+class TplinkDecoE4RRouterTest(TplinkDecoE4RRouter):
+    login_result = '00000\r\n'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.sent = []
+
+    def _code_request(self, query, data=None, use_token=False):
+        self.sent.append((query, data, use_token))
+        if query == 'code=7&asyn=1':
+            return ResponseMock(CHALLENGE, 401)
+        if query == 'code=16&asyn=0' and data == 'enable':
+            return ResponseMock('00000')
+        if query == 'code=16&asyn=0' and data == 'get':
+            return ResponseMock('00000\r\n010001\r\n{}\r\n{}'.format(TEST_NN, TEST_SEQ))
+        if query == 'code=7&asyn=0' and use_token:
+            return ResponseMock(self.login_result)
+        if query == 'code=16&asyn=0' and use_token:
+            return ResponseMock('00000')
+        if query == 'code=11&asyn=0':
+            return ResponseMock('00000')
+        raise ClientException('unexpected code request {}'.format(query))
+
+    def use_fixtures(self, fixtures):
+        self._session = SessionMock(self, fixtures)
+
+
+def _device_list():
+    return dumps({'error_code': 0, 'result': {'device_list': [
+        {'role': 'master', 'device_model': 'E4R', 'hardware_ver': '4.0',
+         'software_ver': '1.2.3 Build 20240101', 'mac': '00-00-00-00-00-01'},
+        {'role': 'slave', 'device_model': 'E4R', 'hardware_ver': '4.0',
+         'software_ver': '1.2.3 Build 20240101', 'mac': '00-00-00-00-00-02'},
+    ]}})
+
+
+def _client_list():
+    return dumps({'error_code': 0, 'result': {'client_list': [
+        {'mac': '00-00-00-00-00-11', 'ip': '10.0.0.11', 'name': b64encode(b'PHONE').decode(),
+         'online': True, 'interface': 'main', 'connection_type': 'band2_4',
+         'down_speed': 100, 'up_speed': 50, 'wire_type': 'wireless'},
+        {'mac': '00-00-00-00-00-12', 'ip': '10.0.0.12', 'name': b64encode(b'LAPTOP').decode(),
+         'online': True, 'wire_type': 'wired', 'down_speed': 0, 'up_speed': 0},
+        {'mac': '00-00-00-00-00-13', 'ip': '10.0.0.13', 'name': b64encode(b'OFFLINE').decode(),
+         'online': False, 'wire_type': 'wired'},
+    ]}})
+
+
+class TestTplinkDecoE4RRouter(TestCase):
+    def test_security_encode_is_deterministic(self):
+        client = TplinkDecoE4RRouterTest('', '')
+        # (ord('A')^ord('x'))=57 -> 57%16=9 ; (ord('B')^ord('y'))=59 -> 59%16=11
+        self.assertEqual(client._security_encode('AB', 'xy', '0123456789abcdef'), '9b')
+
+    def test_authorize_sequence_and_token(self):
+        client = TplinkDecoE4RRouterTest('', 'secretpwd')
+        client.authorize()
+
+        self.assertTrue(client._logged)
+        self.assertEqual(client._ee, '010001')
+        self.assertEqual(client._nn, TEST_NN)
+        self.assertEqual(client._seq, TEST_SEQ)
+
+        # Exact protocol order captured from the router's own login controller.
+        order = [(q, d is not None and d.startswith('set '), t) if q == 'code=16&asyn=0' and t
+                 else (q, d, t) for q, d, t in client.sent]
+        self.assertEqual(order, [
+            ('code=7&asyn=1', None, False),
+            ('code=16&asyn=0', 'enable', False),
+            ('code=16&asyn=0', 'get', False),
+            ('code=7&asyn=0', client.sent[3][1], True),  # login body checked below
+            ('code=16&asyn=0', True, True),              # set <RSA(aes)>
+        ])
+
+        # The id is securityEncode(line3, key=MD5(password), alphabet=line4).
+        expected_token = parse.quote(
+            client._security_encode(CHALLENGE_LINE3, md5(b'secretpwd').hexdigest(), CHALLENGE_LINE4),
+            safe='!()*')
+        self.assertEqual(client._token, expected_token)
+
+        # The code=7 login body is exactly one RSA-512 block (128 hex chars).
+        login_body = client.sent[3][1]
+        self.assertEqual(len(login_body), 128)
+        self.assertTrue(all(c in '0123456789abcdefABCDEF' for c in login_body))
+
+    def test_authorize_raises_on_bad_password(self):
+        client = TplinkDecoE4RRouterTest('', 'wrong')
+        client.login_result = '00007\r\n00006\r\n'  # server rejects the login
+        with self.assertRaises(ClientException):
+            client.authorize()
+        self.assertFalse(client._logged)
+
+    def test_get_firmware(self):
+        client = TplinkDecoE4RRouterTest('', 'pwd')
+        client.authorize()
+        client.use_fixtures({'form=device_list': _device_list()})
+
+        firmware = client.get_firmware()
+        self.assertIsInstance(firmware, Firmware)
+        self.assertEqual(firmware.hardware_version, '4.0')
+        self.assertEqual(firmware.model, 'E4R')
+        self.assertEqual(firmware.firmware_version, '1.2.3 Build 20240101')
+
+    def test_get_status(self):
+        client = TplinkDecoE4RRouterTest('', 'pwd')
+        client.authorize()
+        client.use_fixtures({
+            'form=wan_ipv4': dumps({'error_code': 0, 'result': {
+                'wan': {'dial_type': 'dynamic_ip',
+                        'ip_info': {'mac': '00-00-00-00-00-0A', 'ip': '1.2.3.4', 'gateway': '1.2.3.1'}},
+                'lan': {'ip_info': {'mac': '00-00-00-00-00-0B', 'ip': '192.168.0.1'}}}}),
+            'form=performance': dumps({'error_code': 0, 'result': {'cpu_usage': 0.25, 'mem_usage': 0.5}}),
+            'form=wlan': dumps({'error_code': 0, 'result': {
+                'band2_4': {'host': {'enable': True}, 'guest': {'enable': False}},
+                'band5_1': {'host': {'enable': True}, 'guest': {'enable': False}}}}),
+            'form=client_list': _client_list(),
+        })
+
+        status = client.get_status()
+        self.assertIsInstance(status, Status)
+        self.assertEqual(status.wan_ipv4_addr, '1.2.3.4')
+        self.assertIsInstance(status.wan_ipv4_address, IPv4Address)
+        self.assertEqual(status.lan_ipv4_addr, '192.168.0.1')
+        self.assertEqual(status.wan_macaddr, '00-00-00-00-00-0A')
+        self.assertEqual(status.cpu_usage, 0.25)
+        self.assertEqual(status.mem_usage, 0.5)
+        self.assertTrue(status.wifi_2g_enable)
+        self.assertTrue(status.wifi_5g_enable)
+        self.assertFalse(status.guest_2g_enable)
+
+        self.assertEqual(len(status.devices), 2)  # only online clients
+        self.assertEqual(status.wired_total, 1)
+        self.assertEqual(status.wifi_clients_total, 1)
+        self.assertEqual(status.clients_total, 2)
+
+        device = status.devices[0]
+        self.assertIsInstance(device, Device)
+        self.assertEqual(device.type, Connection.HOST_2G)
+        self.assertEqual(device.macaddr, '00-00-00-00-00-11')
+        self.assertIsInstance(device.macaddress, EUI48)
+        self.assertEqual(device.ipaddr, '10.0.0.11')
+        self.assertEqual(device.hostname, 'PHONE')
+        self.assertEqual(device.down_speed, 100)
+        self.assertEqual(device.up_speed, 50)
+
+    def test_supports_true_and_false(self):
+        client = TplinkDecoE4RRouterTest('', 'pwd')
+        self.assertTrue(client.supports())
+
+        bad = TplinkDecoE4RRouterTest('', 'pwd')
+        bad.login_result = '00007\r\n00006\r\n'
+        self.assertFalse(bad.supports())
+
+    def test_logout(self):
+        client = TplinkDecoE4RRouterTest('', 'pwd')
+        client.authorize()
+        client.logout()
+        self.assertFalse(client._logged)
+        self.assertEqual(client._token, '')
+        self.assertIn(('code=11&asyn=0', None, True), client.sent)
+
+    def test_registered_in_provider(self):
+        clients = list(TplinkRouterProvider.get_clients())
+        self.assertIn('TplinkDecoE4RRouter', clients)
+        # Must be probed before the clients known to over-eagerly accept.
+        idx = clients.index('TplinkDecoE4RRouter')
+        for greedy in ('TPLinkEAP115Client', 'TPLinkSG108EClient', 'TplinkC3200Router'):
+            self.assertLess(idx, clients.index(greedy))
+
+
+if __name__ == '__main__':
+    main()

--- a/tplinkrouterc6u/__init__.py
+++ b/tplinkrouterc6u/__init__.py
@@ -18,6 +18,7 @@ from tplinkrouterc6u.client.xdr import TPLinkXDRClient
 from tplinkrouterc6u.client.wdr import TplinkWDRRouter
 from tplinkrouterc6u.client.r import TPLinkRClient
 from tplinkrouterc6u.client.re330 import TplinkRE330Router
+from tplinkrouterc6u.client.deco_e4r import TplinkDecoE4RRouter
 from tplinkrouterc6u.client.eap115 import TPLinkEAP115Client
 from tplinkrouterc6u.client.cpe210 import TPLinkCPE210Client
 from tplinkrouterc6u.client.vr1200v import TplinkVR1200vRouter

--- a/tplinkrouterc6u/client/deco_e4r.py
+++ b/tplinkrouterc6u/client/deco_e4r.py
@@ -1,0 +1,162 @@
+from hashlib import md5
+from json import loads
+from logging import Logger
+from urllib import parse
+import requests
+from requests import Session
+from tplinkrouterc6u.common.encryption import EncryptionWrapper
+from tplinkrouterc6u.common.exception import ClientException, ClientError
+from tplinkrouterc6u.client.deco import TPLinkDecoClient
+
+
+class TplinkDecoE4RRouter(TPLinkDecoClient):
+    """Client for the TP-Link Deco E4R.
+
+    The E4R does not expose the luci ``/cgi-bin/luci/;stok=`` JSON login used by
+    :class:`TPLinkDecoClient`. Instead it authenticates through the
+    ``/?code=N&asyn=M&id=TOKEN`` protocol (same family as
+    :class:`~tplinkrouterc6u.client.c80.TplinkC80Router` and
+    :class:`~tplinkrouterc6u.client.re330.TplinkRE330Router`). Once logged in the
+    data layer is the ordinary Deco JSON API (``/admin/...?form=...``), so all of
+    the parsing in :class:`TPLinkDecoClient` is reused as-is; only the login
+    handshake and the request transport are overridden here.
+    """
+
+    # securityEncode alphabet / key, identical to the router's encrypt.js and to
+    # the values already used by TplinkC80Router / TplinkRE330Router.
+    ENCODING = ("yLwVl0zKqws7LgKPRQ84Mdt708T1qQ3Ha7xv3H7NyU84p21BriUWBU43odz3iP4rBL3cD02KZciXTysVXiV8"
+                "ngg6vL48rPJyAUw0HurW20xqxv9aYb4M9wK1Ae0wlro510qXeU07kV57fQMc8L6aLgMLwygtc0F10a0Dg70T"
+                "OoouyFhdysuRMO51yY5ZlOZZLEal1h0t9YQW0Ko7oBwmCAHoic4HYbUyVeU3sfQ1xtXcPcf1aT303wAQhv66qzW")
+    KEY = "RDpbLfCPsJZ7fiv"
+    PAD_CHAR = chr(187)
+
+    def __init__(self, host: str, password: str, username: str = 'admin', logger: Logger = None,
+                 verify_ssl: bool = True, timeout: int = 30) -> None:
+        super().__init__(host, password, username, logger, verify_ssl, timeout)
+        self.host = self.host.rstrip('/')
+        self._session = Session()
+        if self._verify_ssl is False:
+            self._session.verify = False
+        # AES session cipher (self._encryption is created by TplinkEncryption).
+        self._nn = ''
+        self._ee = ''
+        self._seq = ''
+        self._token = ''
+        self._headers = {
+            'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+            'X-Requested-With': 'XMLHttpRequest',
+            'Referer': self.host + '/',
+        }
+
+    def supports(self) -> bool:
+        try:
+            self.authorize()
+            return True
+        except Exception:
+            return False
+
+    def authorize(self) -> None:
+        # 1) getTmpKey - unauthenticated challenge carrying the token key material.
+        response = self._code_request('code=7&asyn=1')
+        text = response.text
+        if text.endswith('\r\n'):
+            text = text[:-2]
+        lines = text.split('\r\n')
+        if len(lines) < 5:
+            raise ClientException('TplinkDecoE4RRouter - unexpected challenge response')
+        key_string, alphabet = lines[3], lines[4]
+
+        # id = securityEncode(line3, key=MD5(password), alphabet=line4)
+        password_hash = md5(self.password.encode()).hexdigest()
+        self._token = parse.quote(self._security_encode(key_string, password_hash, alphabet), safe='!()*')
+
+        # 2) GDPR ack (best effort - kept to mirror the web UI handshake).
+        self._code_request('code=16&asyn=0', data='enable')
+
+        # 3) Fetch the session RSA key and sequence number.
+        response = self._code_request('code=16&asyn=0', data='get')
+        key_data = response.text.split('\r\n')
+        if len(key_data) < 4 or key_data[0] != '00000':
+            raise ClientException('TplinkDecoE4RRouter - invalid response for RSA keys')
+        self._ee, self._nn, self._seq = key_data[1], key_data[2], key_data[3]
+        self._encryption = EncryptionWrapper()
+
+        # 4) Login - the credential is the RSA-encrypted password.
+        response = self._code_request('code=7&asyn=0', data=self._rsa_encrypt(self.password), use_token=True)
+        if response.text.split('\r\n')[0] != '00000':
+            raise ClientException('TplinkDecoE4RRouter - login failed, check the router password')
+
+        # 5) Register the AES session key for subsequent encrypted requests.
+        aes_string = self._encryption._get_aes_string()
+        response = self._code_request('code=16&asyn=0', data='set ' + self._rsa_encrypt(aes_string), use_token=True)
+        if response.text.split('\r\n')[0] != '00000':
+            raise ClientException('TplinkDecoE4RRouter - failed to register the session key')
+
+        self._logged = True
+
+    def logout(self) -> None:
+        self._code_request('code=11&asyn=0', use_token=True)
+        self._token = ''
+        self._logged = False
+
+    def request(self, path: str, data: str, ignore_response: bool = False,
+                ignore_errors: bool = False) -> dict | None:
+        if self._logged is False:
+            raise ClientException('TplinkDecoE4RRouter - not authorised')
+
+        encrypted = self._encryption.aes_encrypt(data)
+        body = 'sign={}&data={}'.format(self._signature(len(encrypted)), encrypted)
+
+        separator = '&' if '?' in path else '?'
+        url = '{}/{}{}id={}'.format(self.host, path, separator, self._token)
+
+        response = self._session.post(url, data=body, headers=self._headers,
+                                      timeout=self.timeout, verify=self._verify_ssl)
+
+        if ignore_response:
+            return None
+
+        error = ''
+        try:
+            decrypted = self._encryption.aes_decrypt(response.text)
+            parsed = loads(decrypted)
+            if self._is_valid_response(parsed):
+                return parsed.get(self._data_block)
+            elif ignore_errors:
+                return parsed
+        except Exception as e:
+            error = ('TplinkDecoE4RRouter - An unknown response - {}; Request {}'.format(e, path))
+        error = ('TplinkDecoE4RRouter - Response with error; Request {}'.format(path)) if not error else error
+        if self._logger:
+            self._logger.debug(error)
+        raise ClientError(error)
+
+    def _security_encode(self, text: str, key: str, alphabet: str) -> str:
+        length = max(len(key), len(text))
+        text = text.ljust(length, self.PAD_CHAR)
+        key = key.ljust(length, self.PAD_CHAR)
+        return ''.join(alphabet[(ord(text[i]) ^ ord(key[i])) % len(alphabet)] for i in range(length))
+
+    def _rsa_encrypt(self, text: str) -> str:
+        return EncryptionWrapper.rsa_encrypt(text, self._nn, self._ee)
+
+    def _signature(self, data_length: int) -> str:
+        payload = '{}&s={}'.format(self._encryption._get_aes_string(), int(self._seq) + data_length)
+        signature = ''
+        position = 0
+        while position < len(payload):
+            signature += self._rsa_encrypt(payload[position:position + 53])
+            position += 53
+        return signature
+
+    def _code_request(self, query: str, data: str = None, use_token: bool = False):
+        url = '{}/?{}'.format(self.host, query)
+        if use_token:
+            url += '&id={}'.format(self._token)
+        try:
+            return self._session.post(url, data=data, headers=self._headers,
+                                      timeout=self.timeout, verify=self._verify_ssl)
+        except requests.exceptions.RequestException as e:
+            if self._logger:
+                self._logger.error('TplinkDecoE4RRouter - Network error: {}'.format(e))
+            raise ClientException('TplinkDecoE4RRouter - Network error: {}'.format(e)) from e

--- a/tplinkrouterc6u/provider.py
+++ b/tplinkrouterc6u/provider.py
@@ -21,6 +21,7 @@ from tplinkrouterc6u.client.vr400v2 import TPLinkVR400v2Client
 from tplinkrouterc6u.client.r import TPLinkRClient
 from tplinkrouterc6u.client.wdr import TplinkWDRRouter
 from tplinkrouterc6u.client.re330 import TplinkRE330Router
+from tplinkrouterc6u.client.deco_e4r import TplinkDecoE4RRouter
 from tplinkrouterc6u.client.eap115 import TPLinkEAP115Client
 from tplinkrouterc6u.client.cpe210 import TPLinkCPE210Client
 from tplinkrouterc6u.client.sg108e import TPLinkSG108EClient
@@ -87,6 +88,7 @@ class TplinkRouterProvider:
             TplinkC80Router.__name__: TplinkC80Router,
             TplinkWDRRouter.__name__: TplinkWDRRouter,
             TplinkRE330Router.__name__: TplinkRE330Router,
+            TplinkDecoE4RRouter.__name__: TplinkDecoE4RRouter,
             TplinkC3200Router.__name__: TplinkC3200Router,
             TPLinkEAP115Client.__name__: TPLinkEAP115Client,
             TPLinkCPE210Client.__name__: TPLinkCPE210Client,


### PR DESCRIPTION
## Add support for the TP-Link Deco E4R

New client `TplinkDecoE4RRouter` + auto-detection for the Deco E4R, which no
existing client could authenticate against.

### Protocol
The E4R logs in through the `/?code=N&asyn=M&id=TOKEN` protocol (C80/RE330 family)
but with a distinct sequence, then uses the standard Deco JSON API for data.
Reconstructed from the router's own `modules/login/localLogin/controllers.js`:

1. `POST /?code=7&asyn=1` → `401` challenge `00007\r\n…\r\n<line3>\r\n<line4>\r\n00000`
2. `id = securityEncode(line3, key=MD5(password), alphabet=line4)` — `line4` is the output alphabet (not an RSA key)
3. `POST /?code=16&asyn=0` body `enable`
4. `POST /?code=16&asyn=0` body `get` → RSA-512 session key + seq
5. `POST /?code=7&asyn=0&id=<id>` body `RSA(password)` → **login**
6. `POST /?code=16&asyn=0&id=<id>` body `set <RSA(k=…&i=…)>` → register AES
7. Data: `POST /admin/<x>?form=<y>&id=<id>` with `sign=…&data=<AES-CBC(json)>`, response is AES-encrypted JSON (`error_code`/`result`)

### Implementation
`TplinkDecoE4RRouter` extends `TPLinkDecoClient`, overriding **only** the transport
(`authorize`/`request`/`logout`/`supports`) and reusing all of its JSON data parsing.
Registered in `TplinkRouterProvider` right after `TplinkRE330Router` (before the
greedier legacy clients) so it matches the E4R first; verified it neither shadows
nor is shadowed by C80/RE330/Deco. No changes to any existing client.

### Evidence — live run against a real Deco E4R (firmware 1.3.1), secrets redacted

== auto-detection ==
TplinkRouterProvider.get_client(...) -> TplinkDecoE4RRouter

authorize() -> OK   (session id length = 44 chars, value redacted)

get_firmware():
   model            = E4R
   hardware_version = 4.0
   firmware_version = 1.3.1 Build 20260403 Rel. 8727

get_status():
   clients_total       = 19
   wired_total         = 0
   wifi_clients_total  = 14
   cpu_usage           = 0.31
   mem_usage           = 0.58
   wan_ipv4_addr       = 10.1.x.x
   lan_ipv4_addr       = 10.1.x.x
   wifi_2g / 5g enable = True / True
   len(status.devices) = 19
   sample devices (redacted):
     - Connection.HOST_2G C0-XX-XX-XX-XX-XX 10.1.x.x name=e*** down/up=0/0
     - Connection.HOST_2G D4-XX-XX-XX-XX-XX 10.1.x.x name=E*** down/up=0/0

get_ipv4_status(): wan=10.1.x.x lan=10.1.x.x conntype=dynamic_ip

logout() -> OK

### Tests
$ pytest test/test_client_deco_e4r.py -v
test_authorize_raises_on_bad_password PASSED
test_authorize_sequence_and_token     PASSED
test_get_firmware                     PASSED
test_get_status                       PASSED
test_logout                           PASSED
test_registered_in_provider           PASSED
test_security_encode_is_deterministic PASSED
test_supports_true_and_false          PASSED
8 passed

$ pytest test/            # full existing suite, no regressions
377 passed, 6 subtests passed

$ flake8 tplinkrouterc6u/client/deco_e4r.py test/test_client_deco_e4r.py
clean

8 new unit tests use fully synthetic fixtures (no real device data). Verified
end-to-end against a real Deco E4R on firmware 1.3.1.