### PR TITLE
fix: add TplinkRouterAX72 for firmware requiring RSA-OAEP login signatures

### DIFF
--- a/test/test_client_ax72.py
+++ b/test/test_client_ax72.py
@@ -1,0 +1,122 @@
+from unittest import main, TestCase
+from unittest.mock import patch, Mock
+
+from tplinkrouterc6u import TplinkRouterAX72
+from test_client_c6u import TestTPLinkClient
+
+
+class TestTPLinkClientAX72(TestTPLinkClient):
+    """Inherits get_firmware/get_status/get_ipv4_status/etc.
+    All other tests unchanged from TestTPLinkClient.
+
+    TplinkRouterAX72 extends TplinkRouter directly (unlike TplinkRouterSG, which extends TplinkBaseRouter),
+    so it inherits TplinkRouter's shortened URL scheme too - no path overrides needed here, unlike TestTPLinkClientSG's firmware_path/game_accelerator_path/etc.
+    """
+
+    router_class = TplinkRouterAX72
+
+
+class TestTplinkRouterAX72Unit(TestCase):
+    """Unit tests specific to TplinkRouterAX72's login signature and detection logic.
+
+    authorize() itself, its 403-retry logic, and password encryption are all inherited unchanged from TplinkEncryption/TplinkRouter
+    and are already covered by the base class's own tests
+    - only the pieces this class actually overrides (_get_login_data, _prepare_data, _build_login_signature, supports()) are tested here.
+    """
+
+    def test_supports_password_too_long(self) -> None:
+        long_password = 'a' * 126
+        client = TplinkRouterAX72('http://192.168.0.1', long_password)
+        self.assertFalse(client.supports())
+
+    def test_get_login_data_omits_confirm(self) -> None:
+        """The AX72 rejects a login body containing '&confirm=true' - the standard scheme sends it."""
+        data = TplinkRouterAX72._get_login_data('deadbeef')
+
+        self.assertEqual(data, 'operation=login&password=deadbeef')
+        self.assertNotIn('confirm', data)
+
+    def test_build_login_signature_real_key_size(self) -> None:
+        """Regression test mirroring #171/#185's test_build_login_signature_real_key_size.
+
+        Reuses the same real 512-bit auth key value already published in test_client_sg.py
+        (public key material - safe to reuse, and a genuine 512-bit modulus is what actually matters here, not which device it came from).
+        Confirms this doesn't raise "Plaintext is too long."
+        (which the naive flat 53-byte-per-block chunking - sized for PKCS1v1.5's 11-byte overhead, not OAEP's 42-byte overhead - does raise against a key this size)
+        and produces a whole number of 512-bit (128 hex char) blocks.
+        """
+        client = TplinkRouterAX72('http://192.168.0.1', 'testpassword')
+        client._encryption._key = b'1234567890123456'
+        client._encryption._iv = b'6543210987654321'
+        client.nn = (
+            'ca8f1711cc27576fb0dae0d7df1b6a90465e8ea31ccf46b0004f4c60f6617df'
+            '8fa147502e45353b4d3f8ad38cb9aee9a77d33973ce3d7d681bc2fb0ae242e631'
+        )
+        client.ee = '010001'
+
+        sign = client._build_login_signature(seq_and_len=555111222, hash_value='a' * 64)
+
+        self.assertGreater(len(sign), 0)
+        self.assertEqual(len(sign) % 128, 0)
+
+    def test_prepare_data_hashes_with_sha256_not_md5(self) -> None:
+        """The AX72 expects SHA256(username+password) - the standard scheme's MD5 hash is rejected."""
+        client = TplinkRouterAX72('http://192.168.0.1', 'testpassword', username='admin')
+        client._seq = '100'
+        client.nn = (
+            'ca8f1711cc27576fb0dae0d7df1b6a90465e8ea31ccf46b0004f4c60f6617df'
+            '8fa147502e45353b4d3f8ad38cb9aee9a77d33973ce3d7d681bc2fb0ae242e631'
+        )
+        client.ee = '010001'
+
+        with patch.object(client, '_build_login_signature', return_value='mock_sign') as mock_build_sig:
+            client._prepare_data('operation=login&password=deadbeef')
+
+        hash_value = mock_build_sig.call_args[0][1]
+        self.assertEqual(len(hash_value), 64)  # SHA256 hex digest length; MD5 would be 32
+
+        from hashlib import sha256, md5
+        expected_sha256 = sha256(b'admintestpassword').hexdigest()
+        unexpected_md5 = md5(b'admintestpassword').hexdigest()
+        self.assertEqual(hash_value, expected_sha256)
+        self.assertNotEqual(hash_value, unexpected_md5)
+
+    @patch.object(TplinkRouterAX72, 'authorize')
+    @patch.object(TplinkRouterAX72, 'logout')
+    @patch.object(TplinkRouterAX72, '_request_pwd')
+    @patch.object(TplinkRouterAX72, '_request_seq')
+    def test_supports_true_for_512_bit_auth_key(
+        self, mock_request_seq: Mock, mock_request_pwd: Mock, mock_logout: Mock, mock_authorize: Mock,
+    ) -> None:
+        """A 512-bit auth key (the AX72's actual size) should pass the pre-filter and attempt a real login."""
+        client = TplinkRouterAX72('http://192.168.0.1', 'testpassword')
+
+        def set_nn():
+            client.nn = 'a' * 128  # 128 hex chars = 512 bits
+
+        mock_request_seq.side_effect = set_nn
+
+        self.assertTrue(client.supports())
+        mock_authorize.assert_called_once()
+        mock_logout.assert_called_once()
+
+    @patch.object(TplinkRouterAX72, 'authorize')
+    @patch.object(TplinkRouterAX72, '_request_pwd')
+    @patch.object(TplinkRouterAX72, '_request_seq')
+    def test_supports_false_for_non_512_bit_auth_key(
+        self, mock_request_seq: Mock, mock_request_pwd: Mock, mock_authorize: Mock,
+    ) -> None:
+        """A differently-sized auth key should fail the cheap pre-filter without attempting a real login."""
+        client = TplinkRouterAX72('http://192.168.0.1', 'testpassword')
+
+        def set_nn():
+            client.nn = 'a' * 256  # 1024-bit - a standard-scheme AX-series key size, not the AX72's
+
+        mock_request_seq.side_effect = set_nn
+
+        self.assertFalse(client.supports())
+        mock_authorize.assert_not_called()
+
+
+if __name__ == '__main__':
+    main()

--- a/tplinkrouterc6u/__init__.py
+++ b/tplinkrouterc6u/__init__.py
@@ -1,4 +1,5 @@
 from tplinkrouterc6u.client.c6u import TplinkRouter, TplinkRouterV1_11
+from tplinkrouterc6u.client.ax72 import TplinkRouterAX72
 from tplinkrouterc6u.client.sg import TplinkRouterSG
 from tplinkrouterc6u.client.deco import TPLinkDecoClient
 from tplinkrouterc6u.client_abstract import AbstractRouter

--- a/tplinkrouterc6u/client/ax72.py
+++ b/tplinkrouterc6u/client/ax72.py
@@ -1,0 +1,109 @@
+"""
+TP-Link router client for the Archer AX72 (and possibly other AX-series devices sharing its firmware's login-signature scheme).
+
+The standard AX-series client (TplinkRouter, in c6u.py) signs login requests with MD5 + flat 53-byte PKCS1v1.5-chunked RSA,
+via the shared EncryptionWrapper.get_signature().
+The AX72's firmware instead expects:
+  1. SHA256 hash of username+password instead of MD5
+  2. RSA-OAEP (not PKCS1v1.5) padding for the login signature
+  3. No trailing '&confirm=true' in the login body
+Sending the standard scheme gets a 403 on every login attempt.
+
+Password encryption itself is unaffected - it still uses PKCS1v1.5 against the separate password RSA key (pwdNN/pwdEE),
+inherited unchanged via TplinkEncryption.rsa_encrypt().
+Only the login *signature* differs, which is why this class only overrides _get_login_data(), _prepare_data(), and supports() - authorize() itself,
+its 403-retry logic, and every read endpoint (get_firmware/get_status/get_ipv4_status/etc.) are inherited unchanged from TplinkRouter/TplinkBaseRouter.
+
+This class's signature chunking is intentionally *not* a straight port of TplinkRouterSG's (see #185):
+SG's fix chunks the signature string directly into OAEP-sized pieces.
+The AX72 firmware, as confirmed by capturing and replaying a real login (see test_client_ax72.py's regression test and this project's own history),
+instead expects *nested* chunking - the string is split into 53-byte outer pieces first (matching the legacy PKCS1v1.5 layout),
+and each outer piece is then further split into OAEP-safe inner pieces before RSA-OAEP-encrypting each independently.
+These produce different block boundaries past the first 53 bytes,and only the nested form has been confirmed against a real device
+- simplifying to SG's flatter scheme here would be an unverified behavioral change, not just a style choice.
+
+Confirmed end-to-end (login, get_ipv4_status, get_status, get_firmware, logout) against a real Archer AX72.
+"""
+
+from hashlib import sha256
+
+from Crypto.Cipher import PKCS1_OAEP
+from Crypto.PublicKey.RSA import construct
+from binascii import hexlify
+
+from tplinkrouterc6u.client.c6u import TplinkRouter
+
+# Sized for PKCS1v1.5's 11-byte overhead (matches EncryptionWrapper.get_signature's legacy chunking).
+# Only relevant here as an upper bound: the AX72's 512-bit auth key gives an OAEP capacity (22 bytes) well below this,
+# so the min() below always picks the OAEP-safe size in practice - the cap exists so behavior wouldn't silently change
+# if this class were ever reused against a larger-keyed device.
+SIGNATURE_OFFSET = 53
+# SHA-1 (20 bytes): pycryptodome's PKCS1_OAEP.new() default hash, giving OAEP overhead of 2*20+2 = 42 bytes.
+OAEP_HASH_LEN = 20
+
+
+class TplinkRouterAX72(TplinkRouter):
+    """
+    Client for the Archer AX72 (and any AX-series device presenting the same 512-bit auth key size,
+    which the standard PKCS1v1.5-based signing can't authenticate against - see supports()).
+    """
+
+    def supports(self) -> bool:
+        """Cheap pre-filter (auth key size) before attempting a real login, mirroring TplinkRouterV1_11.
+
+        The auth key TP-Link's /login?form=auth serves is 512-bit (128 hex chars) on the AX72;
+        every standard-scheme AX-series device this project has seen serves a larger key.
+        Key size alone doesn't prove which signing scheme a device expects - a 512-bit key is also compatible with PKCS1v1.5
+        - but a real authorize()+logout() attempt right after settles that,
+        and get_client()'s caller falls through to the next provider if this one raises,
+        so a false-positive pre-filter match costs one extra failed login, not a wrong classification.
+        """
+        if len(self.password) > 125:
+            return False
+
+        try:
+            self._request_pwd()
+            self._request_seq()
+            if len(self.nn) != 128:
+                return False
+            self.authorize()
+            self.logout()
+            return True
+        except Exception:
+            pass
+
+        return False
+
+    @staticmethod
+    def _get_login_data(crypted_pwd: str) -> str:
+        return 'operation=login&password={}'.format(crypted_pwd)
+
+    @staticmethod
+    def _rsa_oaep_encrypt(data: bytes, nn: str, ee: str) -> str:
+        key = construct((int(nn, 16), int(ee, 16)))
+        return hexlify(PKCS1_OAEP.new(key).encrypt(data)).decode()
+
+    def _build_login_signature(self, seq_and_len: int, hash_value: str) -> str:
+        """Nested outer-53/inner-OAEP-safe RSA-OAEP signature - see module docstring for why this differs from TplinkRouterSG's flat chunking."""
+        sign_str = '{}&h={}&s={}'.format(self._encryption._get_aes_string(), hash_value, seq_and_len)
+
+        modulus_bytes = len(self.nn) // 2
+        inner_step = min(SIGNATURE_OFFSET, modulus_bytes - 2 * OAEP_HASH_LEN - 2)
+
+        sign = ''
+        for outer_start in range(0, len(sign_str), SIGNATURE_OFFSET):
+            outer_piece = sign_str[outer_start:outer_start + SIGNATURE_OFFSET].encode()
+            for inner_start in range(0, len(outer_piece), inner_step):
+                chunk = outer_piece[inner_start:inner_start + inner_step]
+                sign += self._rsa_oaep_encrypt(chunk, self.nn, self.ee)
+
+        return sign
+
+    def _prepare_data(self, data: str) -> dict:
+        encrypted_data = self._encryption.aes_encrypt(data)
+        data_len = len(encrypted_data)
+        hash_value = sha256((self.username + self.password).encode()).hexdigest()
+
+        sign = self._build_login_signature(int(self._seq) + data_len, hash_value)
+
+        return {'sign': sign, 'data': encrypted_data}

--- a/tplinkrouterc6u/provider.py
+++ b/tplinkrouterc6u/provider.py
@@ -3,6 +3,7 @@ from logging import Logger
 from tplinkrouterc6u.client.xdr import TPLinkXDRClient
 from tplinkrouterc6u.common.exception import ClientException
 from tplinkrouterc6u.client.c6u import TplinkRouter, TplinkRouterV1_11
+from tplinkrouterc6u.client.ax72 import TplinkRouterAX72
 from tplinkrouterc6u.client.sg import TplinkRouterSG
 from tplinkrouterc6u.client.deco import TPLinkDecoClient
 from tplinkrouterc6u.client_abstract import AbstractRouter
@@ -83,6 +84,7 @@ class TplinkRouterProvider:
             TPLinkRClient.__name__: TPLinkRClient,
             TplinkRouterSG.__name__: TplinkRouterSG,
             TplinkRouterV1_11.__name__: TplinkRouterV1_11,
+            TplinkRouterAX72.__name__: TplinkRouterAX72,
             TplinkRouter.__name__: TplinkRouter,
             TplinkC80Router.__name__: TplinkC80Router,
             TplinkWDRRouter.__name__: TplinkWDRRouter,


### PR DESCRIPTION
## Problem
The Archer AX72's firmware signs login requests with nested RSA-OAEP chunking instead of the flat PKCS1v1.5 chunking TplinkRouter/TplinkEncryption assumes.
The existing chunk size (53 bytes, sized for PKCS1v1.5's 11-byte overhead) is far larger than what fits under OAEP's overhead (2*hLen+2 = 42 bytes) on this device's 512-bit auth key, so every login attempt gets a 403.

## Fix
Adds TplinkRouterAX72(TplinkRouter), overriding only the three pieces that actually differ: SHA256 (not MD5) password hashing, RSA-OAEP (not PKCS1v1.5) login-signature encryption, and no trailing `&confirm=true`.
authorize() itself, its 403-retry logic, and every read endpoint are inherited unchanged. supports() does a cheap auth-key-size pre-filter (matching TplinkRouterV1_11's pattern) before attempting a real login.

Confirmed end-to-end (login, get_ipv4_status, get_status, get_firmware, logout) against a real Archer AX72.

## On the chunking shape (re: #185)
This isn't a straight port of TplinkRouterSG's fix.
SG's fix chunks the signature string directly into OAEP-sized pieces. The AX72, as confirmed by capturing and replaying a real login, expects nested chunking instead - split into 53-byte outer pieces first, each further split into OAEP-safe inner pieces.
These produce different block boundaries past the first 53 bytes,
and only the nested form has been confirmed against real hardware, so I kept it rather than simplifying to match SG's shape unverified.

## Testing
- New test/test_client_ax72.py: inherits the shared get_firmware/get_status/ etc. tests from TestTPLinkClient, plus unit tests for supports(), _get_login_data(), _prepare_data()'s SHA256 hashing, and a test_build_login_signature_real_key_size regression test mirroring #185's (reuses the same public 512-bit key already in test_client_sg.py, since key size is what the math depends on, not the specific device).
- Full suite (433 tests) passes locally; flake8 clean.