### PR TITLE
Add IPv6 to get_status for MR client.

### DIFF
--- a/tplinkrouterc6u/client/mr.py
+++ b/tplinkrouterc6u/client/mr.py
@@ -98,6 +98,7 @@ class TPLinkMRClientBase(AbstractRouter):
         self._nn = None
         self._ee = None
         self._seq = None
+        self._ipv6_support = True
         self._url_rsa_key = 'cgi/getParm'
 
         self._encryption = EncryptionWrapperMR()
@@ -239,6 +240,24 @@ class TPLinkMRClientBase(AbstractRouter):
                                                   int(item.get('totalBytesTx', 0)))
         except Exception:
             pass
+
+        # Auxiliary WAN requests, for routers with IPv6 support
+        wan_aux_values = None
+        if self._ipv6_support:
+            try:
+                wan_aux_acts = [self.ActItem(self.ActItem.GS, 'WAN_IP_CONN',
+                        attrs=['enable', 'X_TP_IPv6Enabled', 'X_TP_ExternalIPv6Address'])]
+                _, wan_aux_values = self.req_act(wan_aux_acts)
+                if wan_aux_values:
+                    for item in self._to_list(wan_aux_values):
+                        if int(item['enable']) == 0 and wan_aux_values.__class__ == list:
+                            continue
+                        status.wan_ipv6_enabled = bool(int(item.get('X_TP_IPv6Enabled', '0')))
+                        status._wan_ipv6_addr = get_ipv6(item.get('X_TP_ExternalIPv6Address', '::'))
+                else:
+                    self._ipv6_support = False
+            except Exception:
+                self._ipv6_support = False
 
         status.devices = list(devices.values())
         status.clients_total = status.wired_total + status.wifi_clients_total + status.guest_clients_total


### PR DESCRIPTION
This adds support for IPv6 to MR client get_status, using an additional WAN_IP_CONN request to the router.
If the router does not provide an expected response, no more IPv6 requests are sent.
Tested working with VR1600v v1, f/w 2.1.0, and VR400 v3, f/w 1.6.0.

[IPv6-responses-mr-style.txt](https://github.com/user-attachments/files/31110462/IPv6-responses-mr-style.txt)
