### PR TITLE
Fix OAEP chunk size for small RSA keys

### DIFF
--- a/tplinkrouterc6u/client/sg.py
+++ b/tplinkrouterc6u/client/sg.py
@@ -164,8 +164,16 @@ class TplinkRouterSG(TplinkBaseRouter):
         sign_str = '{}&h={}&s={}'.format(
             self._get_aes_formatted_key(), self._hash, self._seq + data_len)
         sign = ''
-        for i in range(0, len(sign_str), SIGNATURE_OFFSET):
-            chunk = sign_str[i:i + SIGNATURE_OFFSET]
+
+        # OAEP-SHA1 has a maximum plaintext size of
+        # modulus_bytes - 2 * hash_len - 2. Keep the legacy
+        # SIGNATURE_OFFSET for larger keys while avoiding
+        # "Plaintext is too long" errors with smaller RSA keys.
+        rsa_byte_len = len(self._nn) // 2
+        oaep_step = min(SIGNATURE_OFFSET, rsa_byte_len - 2 * 20 - 2)
+
+        for i in range(0, len(sign_str), oaep_step):
+            chunk = sign_str[i:i + oaep_step]
             sign += self._rsa_oaep_encrypt(chunk, self._nn, self._ee)
         return sign
 


### PR DESCRIPTION
What does this PR do?

Fixes RSA-OAEP signature chunking for routers using small RSA keys.

With OAEP-SHA1, the maximum plaintext size is limited by the RSA modulus size. Using the fixed SIGNATURE_OFFSET value can therefore cause Plaintext is too long errors with smaller RSA keys.

This change calculates the maximum OAEP-safe chunk size from the RSA modulus and uses the smaller of that value and the existing SIGNATURE_OFFSET.

For sufficiently large RSA keys, the existing 53-byte chunk size is preserved.

Why?

I encountered this issue while adding Archer AX55 VPN client support. The router uses the SG/CE-RED encryption scheme, and login failed because the OAEP signature exceeded the maximum plaintext size for the RSA key.

This change fixes the issue while preserving the existing behavior for routers with larger RSA keys.