### PR TITLE
fix: detect TL-SG108E by hardware and populate LAN MAC

### DIFF
--- a/test/test_client_sg108e.py
+++ b/test/test_client_sg108e.py
@@ -69,6 +69,31 @@ class TestTPLinkSG108EClient(TestCase):
 
         self.assertTrue(client.supports())
 
+    def test_supports_by_hardware_str_with_custom_description(self) -> None:
+        # Device Description is user-editable, hardwareStr is not.
+        client = TPLinkSG108EClient('http://192.0.2.23', 'password')
+        client._session = Mock()
+        client._session.cookies = Mock()
+        client._session.cookies.clear = Mock()
+
+        root = Mock()
+        root.status_code = 200
+
+        sysinfo = Mock()
+        sysinfo.status_code = 200
+        sysinfo.text = """<html><script>
+        var info_ds = { descriStr:[\"TPLink-Main-Switch\"], macStr:[\"02:00:00:00:00:01\"],
+        firmwareStr:[\"1.0.0 Build 20230218 Rel.50633\"], hardwareStr:[\"TL-SG108E 6.0\"] };
+        </script></html>"""
+
+        login = Mock()
+        login.status_code = 200
+
+        client._session.get.side_effect = [root, sysinfo]
+        client._session.post.return_value = login
+
+        self.assertTrue(client.supports())
+
     def test_get_ipv4_status_from_ip_settings(self) -> None:
         client = TPLinkSG108EClient('http://192.168.0.23', 'password')
         client._session = Mock()
@@ -136,11 +161,30 @@ class TestTPLinkSG108EClient(TestCase):
                 'link_status': [6, 6, 0, 5, 5, 6, 5, 6, 0, 0],
             },
         })
+        # The MAC lookup is best-effort and must not break the port counts.
+        client.device_info = Mock(side_effect=Exception('system info unavailable'))
 
         status = client.get_status()
         self.assertEqual(status.wired_total, 8)
         # 7 ports link-up (one is down), disabled port ignored.
         self.assertEqual(status.clients_total, 6)
+        self.assertIsNone(status.lan_macaddr)
+
+    def test_get_status_populates_lan_macaddr(self) -> None:
+        client = TPLinkSG108EClient('http://192.0.2.23', 'password')
+
+        client.port_stats = Mock(return_value={
+            'max_port_num': 8,
+            'all_info': {
+                'state': [1, 1, 1, 1, 1, 1, 1, 0, 0, 0],
+                'link_status': [6, 6, 0, 5, 5, 6, 5, 6, 0, 0],
+            },
+        })
+        client.device_info = Mock(return_value={'macStr': '02:00:00:00:00:01'})
+
+        status = client.get_status()
+        # EUI48 stringifies with hyphens in this project.
+        self.assertEqual(status.lan_macaddr.lower(), '02-00-00-00-00-01')
 
 
 if __name__ == '__main__':

--- a/tplinkrouterc6u/client/sg108e.py
+++ b/tplinkrouterc6u/client/sg108e.py
@@ -53,7 +53,11 @@ class TPLinkSG108EClient(AbstractRouter):
                 return True
             info = vars.get("info_ds")
             if isinstance(info, dict):
-                descr = _flatten_dict(info).get("descriStr")
+                flat = _flatten_dict(info)
+                hardware = flat.get("hardwareStr")
+                if isinstance(hardware, str) and "TL-SG" in hardware:
+                    return True
+                descr = flat.get("descriStr")
                 return isinstance(descr, str) and "TL-SG" in descr
             return False
         except Exception:
@@ -127,6 +131,13 @@ class TPLinkSG108EClient(AbstractRouter):
         status.wifi_clients_total = 0
         status.guest_clients_total = 0
         status.devices = []
+        # Best-effort LAN MAC so callers may identify the switch.
+        try:
+            mac = self.device_info().get("macStr")
+            if mac:
+                status._lan_macaddr = get_mac(mac)
+        except Exception:
+            pass
         # Leave other fields unset.
         return status
 


### PR DESCRIPTION
## Problem

On a TL-SG108E v6.0, auto-detection can fail when the Device Description is customized because `supports()` checks `g_title` and `descriStr`, but not the hardware-reported `hardwareStr`.

When detection does succeed, `get_status()` leaves `lan_macaddr` unset. This breaks consumers such as the Home Assistant integration, which uses it as the config entry unique ID.

## Fix

* Check `hardwareStr` for the existing `TL-SG` identifier before falling back to `descriStr`.
* Populate `Status._lan_macaddr` from the switch's `macStr` on a best-effort basis.
* Add regression tests for both cases.

The existing `g_title` and `descriStr` detection paths are unchanged.

## Testing

Tested on:

* TL-SG108E v6.0
* Firmware `1.0.0 Build 20230218 Rel.50633`

Verified on the physical switch with Device Description `TPLink-Main-Switch`:

* `TplinkRouterProvider.get_client()` detects `TPLinkSG108EClient`
* authorization and status retrieval succeed
* `status.lan_macaddr` contains the real switch MAC
* Home Assistant config flow completes successfully
* integration remains healthy after a normal Home Assistant Core restart

Also verified:

* `pytest test/test_client_sg108e.py` — 9 passed
* `pytest test` — 447 passed
* flake8 clean
* GitHub Actions passed on Python 3.10, 3.11, 3.12, 3.13 and 3.14
