### PR TITLE
Add set_ipv4_dhcps (DHCP server toggle), c6u client.

### DIFF
--- a/tplinkrouterc6u/client/c6u.py
+++ b/tplinkrouterc6u/client/c6u.py
@@ -256,6 +256,7 @@ class TplinkBaseRouter(AbstractRouter, TplinkRequest):
         self._url_vpn_client_enable = 'admin/vpn?form=enable'
         self._url_vpn_client_server = 'admin/vpn?form=server'
         self._url_vpn_client_user_list = 'admin/vpn?form=vpn_user_list'
+        self._url_ipv4_dhcps = 'admin/dhcps?form=setting'
         referer = '{}/webpages/index.html'.format(self.host)
         self._headers_request = {'Referer': referer, 'Origin': self.host}
         self._headers_login = {'Referer': referer, 'Content-Type': 'application/x-www-form-urlencoded'}
@@ -385,6 +386,7 @@ class TplinkBaseRouter(AbstractRouter, TplinkRequest):
         status.wan_ipv4_uptime = data.get('wan_ipv4_uptime')
         status.wan_ipv6_enabled = self._str2bool(data.get('wan_ipv6_enable', ''))
         status._wan_ipv6_addr = get_ipv6(data.get('wan_ipv6_ip6addr', '::').split('/')[0])
+        status.ipv4_dhcps = self._str2bool(data.get('lan_ipv4_dhcp_enable'))
         status.mem_usage = data.get('mem_usage')
         status.cpu_usage = data.get('cpu_usage')
         status.conn_type = data.get('conn_type')
@@ -727,6 +729,20 @@ class TplinkBaseRouter(AbstractRouter, TplinkRequest):
         })
         self.request(self._url_vpn_client_user_list, payload)
 
+    def set_ipv4_dhcps(self, enable: bool) -> None:
+        data = self.request(self._url_ipv4_dhcps, 'operation=read')
+        payload = urlencode({
+            'operation': 'write',
+            'enable': 'on' if enable else 'off',
+            'leasetime': data.get('leasetime'),
+            'pri_dns': data.get('pri_dns'),
+            'snd_dns': data.get('snd_dns'),
+            'gateway': data.get('gateway'),
+            'ipaddr_start': data.get('ipaddr_start'),
+            'ipaddr_end': data.get('ipaddr_end'),
+        })
+        self.request(self._url_ipv4_dhcps, payload)
+    
     @staticmethod
     def _str2bool(v) -> bool | None:
         return str(v).lower() in ("yes", "true", "on") if v is not None else None

--- a/tplinkrouterc6u/common/dataclass.py
+++ b/tplinkrouterc6u/common/dataclass.py
@@ -61,6 +61,7 @@ class Status:
     _wan_ipv4_gateway: IPv4Address | None = None
     wan_ipv6_enabled: bool | None = None
     _wan_ipv6_addr: IPv6Address | None = None
+    ipv4_dhcps: bool | None = None
     wired_total: int = 0
     wifi_clients_total: int = 0
     guest_clients_total: int = 0


### PR DESCRIPTION
This allows DHCP server function to be enabled/disabled for the LAN (IPv4) in c6u client.
It may answer issue #159.

Tested working with AX55 f/w 1.5.12.
If the change is accepted, I will raise a PR to add corresponding switch in the main integration.

[dhcps form=setting.txt](https://github.com/user-attachments/files/31110898/dhcps.form.setting.txt)

