### PR TITLE
fix(c6u): handle 'auto' wifi channel without crashing

### DIFF
--- a/test/test_client_c6u.py
+++ b/test/test_client_c6u.py
@@ -1908,6 +1908,22 @@ class TestWifiGeneric(TestCase):
         self.assertEqual(info.ssid, 'Host_2G')
 
     @patch('tplinkrouterc6u.client.c6u.post')
+    def test_get_wifi_channel_auto(self, mock_post):
+        # Firmware returns channel 'auto' for auto-selected channels; must map to None
+        mock_data = {
+            'wireless_2g_enable': 'on',
+            'wireless_2g_ssid': 'Host_2G',
+            'wireless_2g_channel': 'auto'
+        }
+
+        with patch.object(self.client, 'request', return_value=mock_data):
+            info = self.client.get_wifi(Connection.HOST_2G)
+
+        self.assertTrue(info.enable)
+        self.assertEqual(info.ssid, 'Host_2G')
+        self.assertIsNone(info.channel)
+
+    @patch('tplinkrouterc6u.client.c6u.post')
     def test_set_wifi_enhanced(self, mock_post):
         # Verify set_wifi still builds correct data strings
         with patch.object(self.client, 'request') as mock_request:

--- a/tplinkrouterc6u/client/c6u.py
+++ b/tplinkrouterc6u/client/c6u.py
@@ -355,7 +355,10 @@ class TplinkBaseRouter(AbstractRouter, TplinkRequest):
         status.psk_key = get_v('psk_key')
         status.portal_enable = self._str2bool(get_v('portal_enable'))
         status.portal_password = get_v('portal_password')
-        status.channel = int(get_v('channel')) if get_v('channel') else None
+        try:
+            status.channel = int(get_v('channel'))
+        except (TypeError, ValueError):
+            status.channel = None
 
         return status
 


### PR DESCRIPTION
> *This PR was generated by AI-assisted triage.*

Addresses #201 (the wifi-channel part).

You are right that #200 is fixed (by #194) — I have dropped the Content-Type change from this PR since it is not needed. This PR now contains only the `channel: auto` fix:

Firmware on host bands returns `channel: "auto"` for auto-selected channels. `int("auto")` raised `ValueError`, breaking `get_wifi(HOST_2G)` / `get_wifi(HOST_5G)` on the AX73. Non-numeric channels now map to `None`.

## Tests

- `test_get_wifi_channel_auto` — `"auto"` channel yields `channel=None`

Full suite passes, flake8 clean.