### PR TITLE
fix(c6u): surface decrypted body when response is not valid JSON

### DIFF
--- a/test/test_client_c6u.py
+++ b/test/test_client_c6u.py
@@ -1845,6 +1845,32 @@ class TestTPLinkClient(TestCase):
         self.assertEqual(_Stub()._decrypt_response({'data': ''}), {})
         self.assertEqual(_Stub()._decrypt_response({}), {})
 
+    @patch('tplinkrouterc6u.client.c6u.post')
+    def test_request_error_includes_decrypted_body(self, mock_post) -> None:
+        """A non-JSON body that is still AES-encrypted (e.g. an HTTP 500 from a
+        Deco/BE-series Lua dispatcher) must surface the decrypted error instead
+        of a generic 'An unknown response' (see #158)."""
+        client = TplinkRouter('http://192.168.0.1', 'password')
+        client._logged = True
+        client._stok = 'stok'
+        client._sysauth = 'sysauth'
+
+        response = Mock()
+        response.text = 'raw_ciphertext'
+        response.json.side_effect = ValueError('Expecting value: line 1 column 1')
+        mock_post.return_value = response
+
+        with patch.object(client, '_prepare_data', return_value='prepared'), \
+                patch.object(
+                    client._encryption, 'aes_decrypt',
+                    return_value='Failed to execute call dispatcher target: attempt to index global mode',
+                ):
+            with self.assertRaises(ClientError) as ctx:
+                client.request('admin/wireless?form=wlan', 'operation=write')
+
+        self.assertIn('Decrypted response', str(ctx.exception))
+        self.assertIn('attempt to index global mode', str(ctx.exception))
+
 
 class TestAuthMinimal(TestCase):
     def setUp(self):

--- a/tplinkrouterc6u/client/c6u.py
+++ b/tplinkrouterc6u/client/c6u.py
@@ -61,6 +61,12 @@ class TplinkRequest:
         except Exception as e:
             error = ('TplinkRouter - {} - An unknown response - {}; Request {} - Response {}'
                      .format(self.__class__.__name__, e, path, data))
+            if getattr(self, '_encryption', None):
+                try:
+                    error += ' Decrypted response - {}'.format(
+                        self._encryption.aes_decrypt(response.text))
+                except Exception:
+                    pass
         error = ('TplinkRouter - {} - Response with error; Request {} - Response {}'
                  .format(self.__class__.__name__, path, data)) if not error else error
         if self._logger:


### PR DESCRIPTION
> *This PR was generated by AI-assisted triage.*

Relates to #158.

When a write/read fails with an HTTP 500 whose body is still AES-encrypted (no JSON envelope), `response.json()` raises and the real router-side error gets hidden behind the generic `An unknown response` message. This made the Deco BE25 `set_wifi()` failure look like a library bug.

This PR tries to AES-decrypt the raw body on that failure path and appends it to the error message, so the underlying Lua dispatcher traceback is visible:

```
TplinkRouter - TPLinkDecoClient - An unknown response - Expecting value: ... Decrypted response - Failed to execute call dispatcher target ... attempt to index global mode
```

- Only affects the error path (non-JSON body) — no behavior change for working responses
- Guarded by `getattr(self, "_encryption", None)` so non-encrypted clients are untouched

## Tests

- `test_request_error_includes_decrypted_body` — non-JSON body gets decrypted and included in the raised `ClientError`

Full suite: 477 tests pass. flake8 clean.