### PR TITLE
Honor disabled SSL verification for C3200 client

### DIFF
--- a/test/test_client_C3200.py
+++ b/test/test_client_C3200.py
@@ -1,6 +1,7 @@
 from ipaddress import IPv4Address
 from typing import List
 from unittest import main, TestCase
+from unittest.mock import patch
 
 from macaddress import EUI48
 
@@ -15,6 +16,37 @@ from tplinkrouterc6u import (
 
 
 class TestTPLinkC3200Router(TestCase):
+
+    def test_supports_disables_ssl_verification(self) -> None:
+        client = TplinkC3200Router(
+            "https://192.168.1.1",
+            "password",
+            verify_ssl=False,
+        )
+
+        with patch("tplinkrouterc6u.client.c3200.requests.get") as request:
+            request.return_value.status_code = 200
+            request.return_value.text = "Archer"
+
+            self.assertTrue(client.supports())
+
+        request.assert_called_once_with(
+            "https://192.168.1.1",
+            timeout=5,
+            verify=False,
+        )
+
+    def test_authorize_disables_ssl_verification(self) -> None:
+        client = TplinkC3200Router(
+            "https://192.168.1.1",
+            "password",
+            verify_ssl=False,
+        )
+
+        with patch("requests.Session.post"):
+            client.authorize()
+
+        self.assertFalse(client.SESSION.verify)
 
     # Testing the merge_response method
     def test_merge_response(self) -> None:

--- a/tplinkrouterc6u/client/c3200.py
+++ b/tplinkrouterc6u/client/c3200.py
@@ -35,7 +35,11 @@ class TplinkC3200Router(TPLinkMR200Client):
 
         try:
             # This method checks if we can recognize the router type.
-            welcome_page = requests.get(self.host, timeout=5)
+            welcome_page = requests.get(
+                self.host,
+                timeout=5,
+                verify=self._verify_ssl,
+            )
             if welcome_page and welcome_page.status_code == 200 and re.search("Archer", welcome_page.text):
                 return True
         except ClientException:
@@ -49,6 +53,7 @@ class TplinkC3200Router(TPLinkMR200Client):
         # Create the SESSION object and the authorization cookie
         # ———————————————————————————————————————————
         self.SESSION = requests.Session()
+        self.SESSION.verify = self._verify_ssl
 
         if self._logger:
             self._logger.debug("!")


### PR DESCRIPTION
## Summary

- honor `verify_ssl` during the C3200 compatibility probe
- apply `verify_ssl` to the persistent C3200 requests session
- add regression tests for both HTTPS request paths

## Reason

Upstream usage in https://github.com/AlexandrErohin/home-assistant-tplink-router causes a TLS error when trying to add an Archer NX600, although the option for TLS verification is off:
<img height="500" alt="image" src="https://github.com/user-attachments/assets/f9f27644-c231-41d1-ab21-ef8341275663" />



## Test plan

- `python -m unittest discover -s test`
- 470 tests passed
