### PR TITLE
feat: add TL-SG108E port status

### DIFF
--- a/test/test_client_sg108e.py
+++ b/test/test_client_sg108e.py
@@ -1,7 +1,7 @@
 from unittest import TestCase, main
 from unittest.mock import Mock
 
-from tplinkrouterc6u import TPLinkSG108EClient
+from tplinkrouterc6u import PortStatus, TPLinkSG108EClient
 from tplinkrouterc6u.client.sg108e import parse_script_variables
 
 
@@ -185,6 +185,215 @@ class TestTPLinkSG108EClient(TestCase):
         status = client.get_status()
         # EUI48 stringifies with hyphens in this project.
         self.assertEqual(status.lan_macaddr.lower(), '02-00-00-00-00-01')
+
+    def test_get_port_status_maps_live_tl_sg108e_v6_payloads(self) -> None:
+        client = TPLinkSG108EClient('http://192.0.2.23', 'password')
+        client.port_stats = Mock(return_value={
+            'max_port_num': 8,
+            'port_middle_num': 16,
+            'all_info': {
+                'state': [1, 1, 1, 1, 1, 1, 1, 1, 0, 0],
+                'link_status': [6, 6, 6, 6, 5, 0, 0, 0, 0, 0],
+                'pkts': [
+                    6790692, 0, 5572836, 1444,
+                    1090232, 0, 4646114, 1443,
+                    4990331, 0, 690965, 1443,
+                    4147068, 0, 5933003, 1443,
+                    87616, 0, 0, 1443,
+                    0, 0, 0, 0,
+                    0, 0, 0, 0,
+                    0, 0, 0, 0,
+                    0, 0,
+                ],
+            },
+            'state_info': ['Disabled', 'Enabled'],
+            'link_info': [
+                'Link Down', 'Auto', '10Half', '10Full',
+                '100Half', '100Full', '1000Full', '',
+            ],
+        })
+        client.port_settings = Mock(return_value={
+            'max_port_num': 8,
+            'port_middle_num': 16,
+            'all_info': {
+                'state': [1, 1, 1, 1, 1, 1, 1, 1, 0, 0],
+                'trunk_info': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                'spd_cfg': [1, 1, 1, 1, 1, 1, 1, 1, 0, 0],
+                'spd_act': [6, 6, 6, 6, 5, 0, 0, 0, 0, 0],
+                'fc_cfg': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                'fc_act': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            },
+            'trunk_info': [
+                '', ' (LAG1)', ' (LAG2)', ' (LAG3)', ' (LAG4)',
+                ' (LAG5)', ' (LAG6)', ' (LAG7)', ' (LAG8)',
+            ],
+            'state_info': ['Disabled', 'Enabled'],
+            'speed_info': [
+                'Link Down', 'Auto', '10MH', '10MF',
+                '100MH', '100MF', '1000MF', '',
+            ],
+            'flow_info': ['Off', 'On'],
+        })
+
+        ports = client.get_port_status()
+        self.assertEqual(len(ports), 8)
+        self.assertEqual([p.port for p in ports], [1, 2, 3, 4, 5, 6, 7, 8])
+        self.assertTrue(all(isinstance(p, PortStatus) for p in ports))
+
+        port1 = ports[0]
+        self.assertTrue(port1.enabled)
+        self.assertTrue(port1.link_up)
+        self.assertTrue(port1.auto_negotiation)
+        self.assertIsNone(port1.configured_speed)
+        self.assertIsNone(port1.configured_duplex)
+        self.assertEqual(port1.negotiated_speed, 1000)
+        self.assertEqual(port1.negotiated_duplex, 'full')
+        self.assertFalse(port1.flow_control_enabled)
+        self.assertFalse(port1.flow_control_active)
+        self.assertIsNone(port1.lag)
+        self.assertEqual(port1.tx_good_packets, 6790692)
+        self.assertEqual(port1.tx_bad_packets, 0)
+        self.assertEqual(port1.rx_good_packets, 5572836)
+        self.assertEqual(port1.rx_bad_packets, 1444)
+
+        port5 = ports[4]
+        self.assertEqual(port5.negotiated_speed, 100)
+        self.assertEqual(port5.negotiated_duplex, 'full')
+        self.assertEqual(port5.tx_good_packets, 87616)
+        self.assertEqual(port5.tx_bad_packets, 0)
+        self.assertEqual(port5.rx_good_packets, 0)
+        self.assertEqual(port5.rx_bad_packets, 1443)
+
+        port6 = ports[5]
+        self.assertTrue(port6.enabled)
+        self.assertFalse(port6.link_up)
+        self.assertIsNone(port6.negotiated_speed)
+        self.assertIsNone(port6.negotiated_duplex)
+        self.assertEqual(port6.tx_good_packets, 0)
+        self.assertEqual(port6.tx_bad_packets, 0)
+        self.assertEqual(port6.rx_good_packets, 0)
+        self.assertEqual(port6.rx_bad_packets, 0)
+
+        client.port_stats.assert_called_once()
+        client.port_settings.assert_called_once()
+
+    def test_get_port_status_fixed_mode_disabled_and_lag(self) -> None:
+        client = TPLinkSG108EClient('http://192.0.2.23', 'password')
+        client.port_stats = Mock(return_value={
+            'max_port_num': 4,
+            'all_info': {
+                'state': [1, 0, 1, 1],
+                'link_status': [6, 0, 2, 3],
+                'pkts': [
+                    10, 0, 20, 1,
+                    0, 0, 0, 0,
+                    30, 2, 40, 3,
+                    50, 0, 60, 0,
+                ],
+            },
+        })
+        client.port_settings = Mock(return_value={
+            'max_port_num': 4,
+            'all_info': {
+                'state': [1, 0, 1, 1],
+                'trunk_info': [0, 0, 1, 0],
+                'spd_cfg': [1, 1, 4, 6],
+                'spd_act': [6, 0, 2, 6],
+                'fc_cfg': [0, 0, 1, 0],
+                'fc_act': [0, 0, 1, 0],
+            },
+        })
+
+        ports = client.get_port_status()
+        self.assertEqual(len(ports), 4)
+
+        disabled = ports[1]
+        self.assertFalse(disabled.enabled)
+        self.assertFalse(disabled.link_up)
+        self.assertTrue(disabled.auto_negotiation)
+        self.assertIsNone(disabled.configured_speed)
+        self.assertIsNone(disabled.configured_duplex)
+        self.assertIsNone(disabled.lag)
+
+        fixed_half = ports[2]
+        self.assertTrue(fixed_half.enabled)
+        self.assertTrue(fixed_half.link_up)
+        self.assertFalse(fixed_half.auto_negotiation)
+        self.assertEqual(fixed_half.configured_speed, 100)
+        self.assertEqual(fixed_half.configured_duplex, 'half')
+        self.assertEqual(fixed_half.negotiated_speed, 10)
+        self.assertEqual(fixed_half.negotiated_duplex, 'half')
+        self.assertTrue(fixed_half.flow_control_enabled)
+        self.assertTrue(fixed_half.flow_control_active)
+        self.assertEqual(fixed_half.lag, 1)
+
+        fixed_full = ports[3]
+        self.assertFalse(fixed_full.auto_negotiation)
+        self.assertEqual(fixed_full.configured_speed, 1000)
+        self.assertEqual(fixed_full.configured_duplex, 'full')
+        self.assertEqual(fixed_full.negotiated_speed, 1000)
+        self.assertEqual(fixed_full.negotiated_duplex, 'full')
+        self.assertFalse(fixed_full.flow_control_enabled)
+        self.assertFalse(fixed_full.flow_control_active)
+        self.assertIsNone(fixed_full.lag)
+
+    def test_get_port_status_short_and_malformed_arrays(self) -> None:
+        client = TPLinkSG108EClient('http://192.0.2.23', 'password')
+        client.port_stats = Mock(return_value={
+            'max_port_num': 0,
+            'all_info': {
+                'state': [1],
+                'link_status': [6],
+                'pkts': [0, 5],
+            },
+        })
+        client.port_settings = Mock(return_value={
+            'max_port_num': 3,
+            'all_info': {
+                'state': [1],
+                'trunk_info': ['bad'],
+                'spd_cfg': [2],
+                'spd_act': [3],
+                'fc_cfg': [1],
+                'fc_act': ['x'],
+            },
+        })
+
+        ports = client.get_port_status()
+        self.assertEqual(len(ports), 3)
+        self.assertEqual([p.port for p in ports], [1, 2, 3])
+
+        port1 = ports[0]
+        self.assertTrue(port1.enabled)
+        self.assertTrue(port1.link_up)
+        self.assertFalse(port1.auto_negotiation)
+        self.assertEqual(port1.configured_speed, 10)
+        self.assertEqual(port1.configured_duplex, 'half')
+        self.assertEqual(port1.negotiated_speed, 10)
+        self.assertEqual(port1.negotiated_duplex, 'full')
+        self.assertTrue(port1.flow_control_enabled)
+        self.assertIsNone(port1.flow_control_active)
+        self.assertIsNone(port1.lag)
+        self.assertEqual(port1.tx_good_packets, 0)
+        self.assertEqual(port1.tx_bad_packets, 5)
+        self.assertIsNone(port1.rx_good_packets)
+        self.assertIsNone(port1.rx_bad_packets)
+
+        for port in ports[1:]:
+            self.assertIsNone(port.enabled)
+            self.assertIsNone(port.link_up)
+            self.assertIsNone(port.auto_negotiation)
+            self.assertIsNone(port.configured_speed)
+            self.assertIsNone(port.configured_duplex)
+            self.assertIsNone(port.negotiated_speed)
+            self.assertIsNone(port.negotiated_duplex)
+            self.assertIsNone(port.flow_control_enabled)
+            self.assertIsNone(port.flow_control_active)
+            self.assertIsNone(port.lag)
+            self.assertIsNone(port.tx_good_packets)
+            self.assertIsNone(port.tx_bad_packets)
+            self.assertIsNone(port.rx_good_packets)
+            self.assertIsNone(port.rx_bad_packets)
 
 
 if __name__ == '__main__':

--- a/tplinkrouterc6u/__init__.py
+++ b/tplinkrouterc6u/__init__.py
@@ -42,5 +42,6 @@ from tplinkrouterc6u.common.dataclass import (
     VpnClientStatus,
     VpnClientServer,
     VpnClientDevice,
+    PortStatus,
 )
 from tplinkrouterc6u.common.exception import ClientException, ClientError, AuthorizeError

--- a/tplinkrouterc6u/client/sg108e.py
+++ b/tplinkrouterc6u/client/sg108e.py
@@ -11,7 +11,7 @@ from requests import Session
 from macaddress import EUI48
 
 from tplinkrouterc6u.client_abstract import AbstractRouter
-from tplinkrouterc6u.common.dataclass import Firmware, IPv4Status, Status
+from tplinkrouterc6u.common.dataclass import Firmware, IPv4Status, PortStatus, Status
 from tplinkrouterc6u.common.exception import AuthorizeError, ClientError
 from tplinkrouterc6u.common.helper import get_ip, get_mac
 from tplinkrouterc6u.common.package_enum import Connection
@@ -160,6 +160,52 @@ class TPLinkSG108EClient(AbstractRouter):
             mac = self.device_info().get("macStr")
         ipv4._lan_macaddr = get_mac(mac or "00:00:00:00:00:00")
         return ipv4
+
+    def get_port_status(self) -> list[PortStatus]:
+        stats = self.port_stats()
+        settings = self.port_settings()
+        count = _physical_port_count(stats, settings)
+        if count <= 0:
+            return []
+
+        stats_info = _as_dict(stats.get("all_info") if isinstance(stats, dict) else None)
+        settings_info = _as_dict(settings.get("all_info") if isinstance(settings, dict) else None)
+        stats_state = stats_info.get("state")
+        settings_state = settings_info.get("state")
+        link_status = stats_info.get("link_status")
+        spd_cfg = settings_info.get("spd_cfg")
+        spd_act = settings_info.get("spd_act")
+        fc_cfg = settings_info.get("fc_cfg")
+        fc_act = settings_info.get("fc_act")
+        trunk = settings_info.get("trunk_info")
+        pkts = stats_info.get("pkts")
+
+        ports: list[PortStatus] = []
+        for i in range(count):
+            enabled = _enabled_at(stats_state, settings_state, i)
+            auto_neg, cfg_speed, cfg_duplex = _configured_mode(_at(spd_cfg, i))
+            neg_speed, neg_duplex = _negotiated_mode(_at(spd_act, i))
+            base = i * 4
+            ports.append(
+                PortStatus(
+                    port=i + 1,
+                    enabled=enabled,
+                    link_up=_link_up(enabled, _at(link_status, i)),
+                    auto_negotiation=auto_neg,
+                    configured_speed=cfg_speed,
+                    configured_duplex=cfg_duplex,
+                    negotiated_speed=neg_speed,
+                    negotiated_duplex=neg_duplex,
+                    flow_control_enabled=_bool01(_at(fc_cfg, i)),
+                    flow_control_active=_bool01(_at(fc_act, i)),
+                    lag=_lag(_at(trunk, i)),
+                    tx_good_packets=_parse_int(_at(pkts, base)),
+                    tx_bad_packets=_parse_int(_at(pkts, base + 1)),
+                    rx_good_packets=_parse_int(_at(pkts, base + 2)),
+                    rx_bad_packets=_parse_int(_at(pkts, base + 3)),
+                )
+            )
+        return ports
 
     def reboot(self) -> None:
         r = self._session.post(
@@ -429,11 +475,104 @@ def _split_top_level(s: str) -> list[str]:
     return parts
 
 
+_SPEED_DUPLEX = {
+    2: (10, "half"),
+    3: (10, "full"),
+    4: (100, "half"),
+    5: (100, "full"),
+    6: (1000, "full"),
+}
+_LINK_UP_CODES = {1, 2, 3, 4, 5, 6}
+
+
 def _safe_int(value, default: int = 0) -> int:
     try:
         return int(value)
     except Exception:
         return default
+
+
+def _as_dict(value) -> dict:
+    return value if isinstance(value, dict) else {}
+
+
+def _parse_int(value) -> int | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _at(seq, index: int):
+    if not isinstance(seq, list) or index < 0 or index >= len(seq):
+        return None
+    return seq[index]
+
+
+def _bool01(value) -> bool | None:
+    parsed = _parse_int(value)
+    if parsed == 0:
+        return False
+    if parsed == 1:
+        return True
+    return None
+
+
+def _physical_port_count(stats, settings) -> int:
+    for data in (stats, settings):
+        if not isinstance(data, dict):
+            continue
+        n = _parse_int(data.get("max_port_num"))
+        if n is not None and n > 0:
+            return n
+    return 0
+
+
+def _enabled_at(stats_state, settings_state, index: int) -> bool | None:
+    enabled = _bool01(_at(stats_state, index))
+    if enabled is not None:
+        return enabled
+    return _bool01(_at(settings_state, index))
+
+
+def _link_up(enabled: bool | None, code) -> bool | None:
+    if enabled is False:
+        return False
+    parsed = _parse_int(code)
+    if parsed is None:
+        return None
+    if parsed == 0:
+        return False
+    if parsed in _LINK_UP_CODES:
+        return True
+    return None
+
+
+def _configured_mode(code) -> tuple[bool | None, int | None, str | None]:
+    parsed = _parse_int(code)
+    if parsed == 1:
+        return True, None, None
+    decoded = _SPEED_DUPLEX.get(parsed) if parsed is not None else None
+    if decoded is None:
+        return None, None, None
+    return False, decoded[0], decoded[1]
+
+
+def _negotiated_mode(code) -> tuple[int | None, str | None]:
+    parsed = _parse_int(code)
+    decoded = _SPEED_DUPLEX.get(parsed) if parsed is not None else None
+    if decoded is None:
+        return None, None
+    return decoded
+
+
+def _lag(value) -> int | None:
+    parsed = _parse_int(value)
+    if parsed is None or parsed <= 0:
+        return None
+    return parsed
 
 
 def _count_ports_enabled(state, ports_total: int) -> int:

--- a/tplinkrouterc6u/common/dataclass.py
+++ b/tplinkrouterc6u/common/dataclass.py
@@ -440,3 +440,22 @@ class WifiStatus:
     portal_enable: bool | None = None
     portal_password: str | None = None
     channel: int | None = None
+
+
+@dataclass
+class PortStatus:
+    port: int
+    enabled: bool | None = None
+    link_up: bool | None = None
+    auto_negotiation: bool | None = None
+    configured_speed: int | None = None
+    configured_duplex: str | None = None
+    negotiated_speed: int | None = None
+    negotiated_duplex: str | None = None
+    flow_control_enabled: bool | None = None
+    flow_control_active: bool | None = None
+    lag: int | None = None
+    tx_good_packets: int | None = None
+    tx_bad_packets: int | None = None
+    rx_good_packets: int | None = None
+    rx_bad_packets: int | None = None


### PR DESCRIPTION
## Summary

Add a typed, read-only per-port status API for TL-SG108E switches using the
existing `port_stats()` and `port_settings()` data.

This adds:

- a public `PortStatus` dataclass;
- `TPLinkSG108EClient.get_port_status()`;
- normalized physical port numbering and enabled/link state;
- configured auto-negotiation, speed and duplex;
- negotiated speed and duplex;
- configured and active flow control;
- LAG membership;
- TX/RX good and bad packet counters.

The existing raw SG108E methods are unchanged, and no methods are added to
`AbstractRouter`.

Missing or malformed individual values are returned as `None` where
appropriate. Endpoint/request errors continue to propagate normally.

The packet counters are packet counts rather than byte counters and can be
reset by the switch.

No configuration-changing functionality is added.

## Testing

Tested on:

- TL-SG108E v6.0
- Firmware `1.0.0 Build 20230218 Rel.50633`

Physical switch validation:

- returns exactly 8 physical ports numbered 1–8;
- observed 5 linked ports;
- ports 1–4 negotiated at 1000 Mbps/full duplex;
- port 5 negotiated at 100 Mbps/full duplex;
- disconnected ports decode without negotiated speed/duplex;
- packet counters are returned correctly;
- repeated reads leave port enable state, LAG configuration, configured
  speed mode and configured flow control unchanged.

Also verified:

- `pytest test/test_client_sg108e.py` — 12 passed
- `pytest test` — 471 passed
- flake8 clean
- `git diff --check` clean
- GitHub Actions passed on Python 3.10, 3.11, 3.12, 3.13 and 3.14