### PR TITLE
feat(xdr): add PPPoE WAN connect/disconnect (TL-XDR6010)

### DIFF
--- a/test/test_client_xdr.py
+++ b/test/test_client_xdr.py
@@ -79,6 +79,56 @@ maximum-scale=2.0, user-scalable=yes" />
         self.assertIn('logout', check_payload['system'])
         self.assertEqual(check_payload['system']['logout'], None)
 
+    def test_pppoe_connect(self) -> None:
+        mock_data = json.loads('''{"error_code":0}''')
+        check_payload = {}
+
+        class TPLinkXDRClientTest(TPLinkXDRClient):
+            def _request(self, payload: dict) -> dict:
+                nonlocal check_payload
+                check_payload = payload
+                return mock_data
+
+        client = TPLinkXDRClientTest('', '')
+        client.pppoe_connect()
+
+        self.assertEqual(check_payload['method'], 'do')
+        self.assertIn('network', check_payload)
+        self.assertIn('change_wan_status', check_payload['network'])
+        self.assertEqual(check_payload['network']['change_wan_status']['proto'], 'pppoe')
+        self.assertEqual(check_payload['network']['change_wan_status']['operate'], 'connect')
+
+    def test_pppoe_disconnect(self) -> None:
+        mock_data = json.loads('''{"error_code":0}''')
+        check_payload = {}
+
+        class TPLinkXDRClientTest(TPLinkXDRClient):
+            def _request(self, payload: dict) -> dict:
+                nonlocal check_payload
+                check_payload = payload
+                return mock_data
+
+        client = TPLinkXDRClientTest('', '')
+        client.pppoe_disconnect()
+
+        self.assertEqual(check_payload['method'], 'do')
+        self.assertIn('network', check_payload)
+        self.assertIn('change_wan_status', check_payload['network'])
+        self.assertEqual(check_payload['network']['change_wan_status']['proto'], 'pppoe')
+        self.assertEqual(check_payload['network']['change_wan_status']['operate'], 'disconnect')
+
+    def test_pppoe_connect_raises_on_error(self) -> None:
+        from tplinkrouterc6u.common.exception import ClientException
+        mock_data = json.loads('''{"error_code":-1}''')
+
+        class TPLinkXDRClientTest(TPLinkXDRClient):
+            def _request(self, payload: dict) -> dict:
+                return mock_data
+
+        client = TPLinkXDRClientTest('', '')
+        with self.assertRaises(ClientException):
+            client.pppoe_connect()
+
     def test_get_firmware(self) -> None:
         mock_data = json.loads('''
 {

--- a/tplinkrouterc6u/client/xdr.py
+++ b/tplinkrouterc6u/client/xdr.py
@@ -100,6 +100,34 @@ class TPLinkXDRClient(AbstractRouter):
                                   format(self.__class__, data['error_code']))
         self._stok = ''
 
+    def pppoe_connect(self) -> None:
+        data = self._request({
+            'method': 'do',
+            'network': {
+                'change_wan_status': {
+                    'proto': 'pppoe',
+                    'operate': 'connect',
+                },
+            },
+        })
+        if data['error_code'] != 0:
+            raise ClientException('TplinkRouter - {} - pppoe connect failed, code - {}'.
+                                  format(self.__class__, data['error_code']))
+
+    def pppoe_disconnect(self) -> None:
+        data = self._request({
+            'method': 'do',
+            'network': {
+                'change_wan_status': {
+                    'proto': 'pppoe',
+                    'operate': 'disconnect',
+                },
+            },
+        })
+        if data['error_code'] != 0:
+            raise ClientException('TplinkRouter - {} - pppoe disconnect failed, code - {}'.
+                                  format(self.__class__, data['error_code']))
+
     def get_firmware(self) -> Firmware:
         data = self._request({
             'method': 'get',


### PR DESCRIPTION
> *This PR was generated by AI-assisted triage.*

Addresses #80 (per your request to make this a separate PR).

The TL-XDR6010 (and the wider TL-XDR/TL-7DR family) already gets basic support through the `TL-XDR` series detection. This PR adds the missing WAN connection reset so flaky PPPoE sessions can be recovered:

- `pppoe_connect()` — `network.change_wan_status` with `operate: connect`
- `pppoe_disconnect()` — same endpoint with `operate: disconnect`

Both raise `ClientException` on a non-zero `error_code`, matching the `reboot`/`set_wifi` conventions in the same class. The payload shape was validated on a TL-XDR6010 by @FerdinandSu on his fork.

## Tests

- `test_pppoe_connect` / `test_pppoe_disconnect` — assert exact request payloads
- `test_pppoe_connect_raises_on_error` — non-zero error_code raises

Full suite passes (471 tests), flake8 clean.