### PR TITLE
fix(c6u): retry authorize on empty/partial login data block

### DIFF
--- a/test/test_client_c6u.py
+++ b/test/test_client_c6u.py
@@ -1866,6 +1866,130 @@ class TestAuthMinimal(TestCase):
             self.client._prepare_data('data')
             self.assertFalse(mock_sign.call_args[0][1], "Should pass False when logged")
 
+    def test_authorize_retries_on_empty_data_block(self) -> None:
+        """The router intermittently returns an empty/partial data block on login
+        (e.g. KeyError 'data' on Mercusys MR80X). authorize() must retry the full
+        login sequence instead of failing on the first attempt."""
+        class Client(TplinkRouter):
+            def __init__(self):
+                super().__init__('http://192.168.0.1', 'password')
+                self.login_calls = 0
+
+            def _request_pwd(self) -> None:
+                self._pwdNN = '00'
+                self._pwdEE = '010001'
+
+            def _request_seq(self) -> None:
+                self._seq = '100'
+
+            def _try_login(self):
+                self.login_calls += 1
+
+                class Resp:
+                    headers = {'set-cookie': 'sysauth=test_sysauth_cookie; path=/'}
+                    status_code = 200
+
+                    def json(self):
+                        return {'success': True, 'data': 'encrypted'}
+
+                    @property
+                    def text(self):
+                        return 'login response'
+
+                return Resp()
+
+        client = Client()
+        # First login attempt: empty data block -> KeyError. Second: valid stok.
+        with patch.object(client, '_decrypt_response', side_effect=[
+                {}, {'data': {'stok': 'retried_stok'}}]):
+            client.authorize()
+
+        self.assertTrue(client._logged)
+        self.assertEqual(client._stok, 'retried_stok')
+        self.assertEqual(client._sysauth, 'test_sysauth_cookie')
+        self.assertEqual(client.login_calls, 2)
+
+    def test_authorize_raises_after_retries_on_empty_data_block(self) -> None:
+        class Client(TplinkRouter):
+            def __init__(self):
+                super().__init__('http://192.168.0.1', 'password')
+                self.login_calls = 0
+
+            def _request_pwd(self) -> None:
+                self._pwdNN = '00'
+                self._pwdEE = '010001'
+
+            def _request_seq(self) -> None:
+                self._seq = '100'
+
+            def _try_login(self):
+                self.login_calls += 1
+
+                class Resp:
+                    headers = {'set-cookie': 'sysauth=test_sysauth_cookie; path=/'}
+                    status_code = 200
+
+                    def json(self):
+                        return {'success': True, 'data': 'encrypted'}
+
+                    @property
+                    def text(self):
+                        return 'login response'
+
+                return Resp()
+
+        client = Client()
+        with patch.object(client, '_decrypt_response', return_value={}):
+            with self.assertRaises(ClientException) as ctx:
+                client.authorize()
+
+        self.assertIn('Cannot authorize', str(ctx.exception))
+        self.assertFalse(client._logged)
+        self.assertEqual(client.login_calls, 3)
+
+    def test_authorize_does_not_retry_content_full_failure(self) -> None:
+        """A content-ful failure (e.g. wrong password with an errorcode in the
+        data block) must NOT be retried — that would hammer the router's
+        account lockout. Only an empty/partial response is retried."""
+        class Client(TplinkRouter):
+            def __init__(self):
+                super().__init__('http://192.168.0.1', 'wrongpassword')
+                self.login_calls = 0
+
+            def _request_pwd(self) -> None:
+                self._pwdNN = '00'
+                self._pwdEE = '010001'
+
+            def _request_seq(self) -> None:
+                self._seq = '100'
+
+            def _try_login(self):
+                self.login_calls += 1
+
+                class Resp:
+                    headers = {'set-cookie': 'sysauth=x; path=/'}
+                    status_code = 200
+
+                    def json(self):
+                        return {'success': True, 'data': 'encrypted'}
+
+                    @property
+                    def text(self):
+                        return 'login response'
+
+                return Resp()
+
+        client = Client()
+        # data block present but no stok (e.g. {'errorcode': 'invalid password'})
+        with patch.object(client, '_decrypt_response', return_value={
+                'errorcode': 'invalid password'}):
+            with self.assertRaises(ClientException) as ctx:
+                client.authorize()
+
+        self.assertIn('Cannot authorize', str(ctx.exception))
+        self.assertFalse(client._logged)
+        self.assertEqual(client.login_calls, 1)
+
 
 class TestWifiGeneric(TestCase):
     def setUp(self):

--- a/tplinkrouterc6u/client/c6u.py
+++ b/tplinkrouterc6u/client/c6u.py
@@ -127,22 +127,42 @@ class TplinkEncryption(TplinkRequest):
             response = self._try_login()
 
         data = response.text
-        try:
-            data = response.json()
-            data = self._decrypt_response(data)
+        attempts = 0
+        while True:
+            try:
+                data = response.json()
+                data = self._decrypt_response(data)
 
-            self._stok = data[self._data_block]['stok']
-            regex_result = search(
-                'sysauth=(.*);', response.headers['set-cookie'])
-            self._sysauth = regex_result.group(1)
-            self._logged = True
-
-        except Exception as e:
-            error = ("TplinkRouter - {} - Cannot authorize! Error - {}; Response - {}"
-                     .format(self.__class__.__name__, e, data))
-            if self._logger:
-                self._logger.debug(error)
-            raise ClientException(error)
+                self._stok = data[self._data_block]['stok']
+                regex_result = search(
+                    'sysauth=(.*);', response.headers['set-cookie'])
+                self._sysauth = regex_result.group(1)
+                self._logged = True
+                return
+            except Exception as e:
+                attempts += 1
+                if attempts >= 3:
+                    error = ("TplinkRouter - {} - Cannot authorize! Error - {}; Response - {}"
+                             .format(self.__class__.__name__, e, data))
+                    if self._logger:
+                        self._logger.debug(error)
+                    raise ClientException(error)
+                # Only retry when the router returned an empty response (a
+                # transient WAN renegotiation hiccup, e.g. MR80X returning {}).
+                # Never retry a content-ful failure such as a wrong password,
+                # which would hammer the router's account lockout.
+                if data:
+                    raise ClientException(
+                        "TplinkRouter - {} - Cannot authorize! Error - {}; Response - {}"
+                        .format(self.__class__.__name__, e, data))
+                # The router sometimes returns an empty data block on login
+                # (e.g. intermittent KeyError 'data' on Mercusys MR80X);
+                # retry the full login sequence before giving up.
+                self._logged = False
+                self._request_pwd()
+                self._request_seq()
+                response = self._try_login()
+                data = response.text
 
     def _request_pwd(self) -> None:
         url = '{}/cgi-bin/luci/;stok=/login?form=keys'.format(self.host)


### PR DESCRIPTION
> *This PR was generated by AI-assisted triage.*

Addresses home-assistant-tplink-router #357.

The router intermittently returns an empty or partial `data` block during login (e.g. `KeyError: data` on Mercusys MR80X), failing the whole integration setup. `authorize()` now retries the full login sequence up to three times before raising.

- Only on the encrypted login path; a genuinely wrong password still fails immediately with the same `Login failed` error.
- Bounded (3 attempts), so a persistent failure is not hidden.

## Tests

- `test_authorize_retries_on_empty_data_block` — succeeds on the retry
- `test_authorize_raises_after_retries_on_empty_data_block` — still raises after 3 attempts

Full suite passes (474 tests), flake8 clean.