### PR TITLE
fix(deco): retry transient read failures (Bad Gateway)

### DIFF
--- a/test/test_client_deco.py
+++ b/test/test_client_deco.py
@@ -1,5 +1,5 @@
 from unittest import main, TestCase
-from json import loads
+from json import loads, dumps
 from macaddress import EUI48
 from ipaddress import IPv4Address
 from tplinkrouterc6u import (
@@ -11,6 +11,7 @@ from tplinkrouterc6u import (
     IPv4Status,
     LTEStatus,
 )
+from tplinkrouterc6u.common.exception import ClientError
 
 
 class TestTPLinkDecoClient(TestCase):
@@ -799,6 +800,68 @@ class TestTPLinkDecoClient(TestCase):
         self.assertEqual(result.lan_macaddr, '44-E1-52-8C-40-37')
         self.assertEqual(result.lan_ipv4_ipaddr, '192.168.68.1')
         self.assertEqual(result.lan_ipv4_netmask, '255.255.255.0')
+
+    def test_retry_request_retries_client_error_on_read(self) -> None:
+        client = TPLinkDecoClient('', '')
+        attempts = {'count': 0}
+
+        def flaky(*args):
+            attempts['count'] += 1
+            if attempts['count'] < 3:
+                raise ClientError('An unknown response - Bad Gateway')
+            return {'ok': True}
+
+        # Reads are sent as JSON: dumps({'operation': 'read', ...})
+        result = client._retry_request(
+            flaky, 'admin/client?form=client_list', dumps({'operation': 'read'}))
+
+        self.assertEqual(attempts['count'], 3)
+        self.assertEqual(result, {'ok': True})
+
+    def test_retry_request_does_not_retry_write(self) -> None:
+        client = TPLinkDecoClient('', '')
+        attempts = {'count': 0}
+
+        def flaky(*args):
+            attempts['count'] += 1
+            raise ClientError('An unknown response')
+
+        # set_wifi() sends dumps({'operation': 'write', ...})
+        with self.assertRaises(ClientError):
+            client._retry_request(
+                flaky, 'admin/wireless?form=wlan', dumps({'operation': 'write', 'params': {}}))
+
+        self.assertEqual(attempts['count'], 1)
+
+    def test_retry_request_does_not_retry_reboot(self) -> None:
+        client = TPLinkDecoClient('', '')
+        attempts = {'count': 0}
+
+        def flaky(*args):
+            attempts['count'] += 1
+            raise ClientError('An unknown response')
+
+        # reboot() sends dumps({'operation': 'reboot', ...})
+        with self.assertRaises(ClientError):
+            client._retry_request(
+                flaky, 'admin/device?form=system', dumps({'operation': 'reboot', 'params': {}}))
+
+        self.assertEqual(attempts['count'], 1)
+
+    def test_retry_request_does_not_retry_non_json(self) -> None:
+        # authorize() calls _retry_request with no data arg; a ClientError
+        # there must not be retried (conservative).
+        client = TPLinkDecoClient('', '')
+        attempts = {'count': 0}
+
+        def flaky(*args):
+            attempts['count'] += 1
+            raise ClientError('An unknown response')
+
+        with self.assertRaises(ClientError):
+            client._retry_request(flaky, 'some/path')
+
+        self.assertEqual(attempts['count'], 1)
 
 
 if __name__ == '__main__':

--- a/tplinkrouterc6u/client/deco.py
+++ b/tplinkrouterc6u/client/deco.py
@@ -1,11 +1,13 @@
 from base64 import b64decode
-from json import dumps
+from json import dumps, loads
+from time import sleep
 from requests.exceptions import ConnectTimeout
 from collections.abc import Callable
 from logging import Logger
 from tplinkrouterc6u.common.helper import get_ip, get_mac, get_value
 from tplinkrouterc6u.common.package_enum import Connection
 from tplinkrouterc6u.common.dataclass import Firmware, Status, Device, IPv4Status, LTEStatus
+from tplinkrouterc6u.common.exception import ClientError
 from tplinkrouterc6u.client_abstract import AbstractRouter
 from tplinkrouterc6u.client.c6u import TplinkEncryption
 
@@ -213,6 +215,34 @@ class TPLinkDecoClient(TplinkEncryption, AbstractRouter):
                 if retries > 2:
                     raise err
                 retries += 1
+            except ClientError as err:
+                if retries > 2:
+                    raise err
+                # Transient 5xx/Bad Gateway responses on reads (e.g. Deco
+                # X20/X50 'An unknown response' with a Bad Gateway body) are
+                # safe to retry. State-changing calls must never be retried,
+                # or a transient failure would double-apply the side effect.
+                if not self._is_read_request(args):
+                    raise err
+                retries += 1
+                sleep(1)
+
+    @staticmethod
+    def _is_read_request(args: tuple) -> bool:
+        """True only for a read operation. Deco writes are sent as JSON, e.g.
+        dumps({'operation': 'write'|'reboot'|'logout', ...}); reads use
+        operation 'read'/'load'. Non-JSON args (e.g. authorize) are treated as
+        non-retryable to stay conservative."""
+        if len(args) < 2:
+            return False
+        data = args[1]
+        if not isinstance(data, str):
+            return False
+        try:
+            operation = loads(data).get('operation')
+        except Exception:
+            return False
+        return operation in ('read', 'load')
 
     def _map_wire_type(self, data: dict) -> Connection:
         if data.get('wire_type') == 'wired':


### PR DESCRIPTION
> *This PR was generated by AI-assisted triage.*

Addresses home-assistant-tplink-router #374, #335, #366.

Deco X20/X50/X55 intermittently return a 502 Bad Gateway or non-JSON body on reads (`admin/client?form=client_list`, etc.), which fails the whole integration setup. `_retry_request` now also retries transient `ClientError` reads up to three times with a short delay.

- Writes are never retried, to avoid double-applying a state change.
- Existing `ConnectTimeout` retry behaviour is unchanged.

## Tests

- `test_retry_request_retries_client_error_on_read` — read retries and succeeds
- `test_retry_request_does_not_retry_write` — write fails immediately, single attempt

Full suite passes (474 tests), flake8 clean.