### PR TITLE
fix(encryption): ignore invalid UTF-8 in decrypted payloads

### DIFF
--- a/test/test_common_encryption.py
+++ b/test/test_common_encryption.py
@@ -17,6 +17,27 @@ class TestEncryptionWrapper(TestCase):
         ciphertext = wrapper.aes_encrypt(plaintext)
         self.assertEqual(wrapper.aes_decrypt(ciphertext), plaintext)
 
+    def test_aes_decrypt_ignores_invalid_utf8_bytes(self) -> None:
+        """Garbage bytes in a decrypted payload (e.g. a device nickname with
+        invalid UTF-8 from the Deco app, HA #374) must not crash decrypt —
+        the surrounding JSON must still parse."""
+        from base64 import b64encode
+        from Crypto.Cipher import AES
+        from Crypto.Util.Padding import pad
+
+        wrapper = EncryptionWrapper()
+        # Build a valid JSON string that also contains an invalid UTF-8 byte
+        # sequence (0xab is not a valid start byte in UTF-8).
+        raw = b'{"nickname":"abc\xab\x99xyz"}'
+        cipher = AES.new(wrapper._key, AES.MODE_CBC, wrapper._iv)
+        ciphertext = b64encode(cipher.encrypt(pad(raw, AES.block_size))).decode()
+
+        result = wrapper.aes_decrypt(ciphertext)
+        # Invalid bytes are dropped, but the surrounding valid text survives.
+        self.assertIn('nickname', result)
+        self.assertIn('abc', result)
+        self.assertIn('xyz', result)
+
 
 if __name__ == '__main__':
     main()

--- a/tplinkrouterc6u/common/encryption.py
+++ b/tplinkrouterc6u/common/encryption.py
@@ -29,7 +29,10 @@ class EncryptionWrapper:
         cipher = AES.new(self._key, AES.MODE_CBC, self._iv)
         decrypted = cipher.decrypt(enc)
         result = self._unpad(decrypted)
-        return result.decode()
+        # The decrypted payload may contain invalid UTF-8 bytes (e.g. garbage
+        # in a device nickname from the Deco app, see HA #374). Ignoring them
+        # lets the surrounding JSON parse instead of crashing the whole setup.
+        return result.decode('utf-8', errors='ignore')
 
     @staticmethod
     def rsa_encrypt(data: str, nn: str, ee: str) -> str:


### PR DESCRIPTION
> *This PR was generated by AI-assisted triage.*

Addresses home-assistant-tplink-router #374.

The Deco app can write garbage bytes (invalid UTF-8) into a device nickname, e.g. `"nickname":"m\xab\\^^\x99\xe9\xed"`. When the encrypted `admin/device?form=device_list` response is decrypted and decoded, the strict UTF-8 decode raises `UnicodeDecodeError`, which crashes the whole integration setup.

This PR makes `EncryptionWrapper.aes_decrypt()` decode with `errors="ignore"`, so invalid bytes are dropped and the surrounding valid JSON still parses. This matches the approach the reporter (dmilotic) suggested and tested: `result.decode(errors="ignore")`.

## Tests

- `test_aes_decrypt_ignores_invalid_utf8_bytes` — a payload containing invalid UTF-8 bytes decrypts without raising, preserving the surrounding valid text.

Full suite passes (469 tests), flake8 clean.