### PR TITLE
Fix MR200 LTE status returning raw strings instead of ints

### DIFF
--- a/test/test_client_mr_200.py
+++ b/test/test_client_mr_200.py
@@ -38,6 +38,39 @@ class TestTPLinkMR200Client(TestCase):
 
         self.assertEqual(result, True)
 
+    def test_get_lte_status(self):
+        values = {
+            '0': {
+                'enable': '1',
+                'connectStatus': '5',
+                'networkType': '3',
+                'simStatus': '5',
+                'signalStrength': '4',
+            },
+            '1': {
+                'totalStatistics': '81234567',
+                'curRxSpeed': '45120',
+                'curTxSpeed': '9310',
+            },
+            '2': {'profileName': 'Carrier'},
+        }
+
+        with patch.object(TPLinkMR200Client, 'req_act', return_value=(0, values)), \
+                patch.object(TPLinkMR200Client, 'get_sms', return_value=[]):
+            status = self.obj.get_lte_status()
+
+        self.assertEqual(status.enable, 1)
+        self.assertEqual(status.connect_status, 5)
+        self.assertEqual(status.network_type, 3)
+        self.assertEqual(status.sim_status, 5)
+        self.assertEqual(status.sig_level, 4)
+        self.assertEqual(status.total_statistics, 81234567)
+        self.assertEqual(status.cur_rx_speed, 45120)
+        self.assertEqual(status.cur_tx_speed, 9310)
+        self.assertEqual(status.isp_name, 'Carrier')
+        self.assertEqual(status.network_type_info, '4G LTE')
+        self.assertEqual(status.sim_status_info, 'SIM unlocked. Authentication succeeded.')
+
 
 if __name__ == '__main__':
     main()

--- a/tplinkrouterc6u/client/mr200.py
+++ b/tplinkrouterc6u/client/mr200.py
@@ -100,13 +100,13 @@ class TPLinkMR200Client(TPLinkMRClient):
             self.ActItem(self.ActItem.GET, 'LTE_WAN_CFG', '2,1,0,0,0,0'),
         ]
         _, values = self.req_act(acts)
-        
+
         status.enable = int(values['0'].get('enable', 0))
         status.connect_status = int(values['0'].get('connectStatus', 0))
         status.network_type = int(values['0'].get('networkType', 0))
         status.sim_status = int(values['0'].get('simStatus', 0))
         status.sig_level = int(values['0'].get('signalStrength', 0))
-        
+
         status.total_statistics = int(float(values['1'].get('totalStatistics', 0)))
         status.cur_rx_speed = int(values['1'].get('curRxSpeed', 0))
         status.cur_tx_speed = int(values['1'].get('curTxSpeed', 0))

--- a/tplinkrouterc6u/client/mr200.py
+++ b/tplinkrouterc6u/client/mr200.py
@@ -100,16 +100,16 @@ class TPLinkMR200Client(TPLinkMRClient):
             self.ActItem(self.ActItem.GET, 'LTE_WAN_CFG', '2,1,0,0,0,0'),
         ]
         _, values = self.req_act(acts)
-
-        status.enable = values['0'].get('enable', 0)
-        status.connect_status = values['0'].get('connectStatus', 0)
-        status.network_type = values['0'].get('networkType', 0)
-        status.sim_status = values['0'].get('simStatus', 0)
-        status.sig_level = values['0'].get('signalStrength', 0)
-
-        status.total_statistics = values['1'].get('totalStatistics', 0)
-        status.cur_rx_speed = values['1'].get('curRxSpeed', 0)
-        status.cur_tx_speed = values['1'].get('curTxSpeed', 0)
+        
+        status.enable = int(values['0'].get('enable', 0))
+        status.connect_status = int(values['0'].get('connectStatus', 0))
+        status.network_type = int(values['0'].get('networkType', 0))
+        status.sim_status = int(values['0'].get('simStatus', 0))
+        status.sig_level = int(values['0'].get('signalStrength', 0))
+        
+        status.total_statistics = int(float(values['1'].get('totalStatistics', 0)))
+        status.cur_rx_speed = int(values['1'].get('curRxSpeed', 0))
+        status.cur_tx_speed = int(values['1'].get('curTxSpeed', 0))
 
         status.isp_name = values['2'].get('profileName', '')
 


### PR DESCRIPTION
### Problem

`TPLinkMR200Client.get_lte_status()` assigns values straight from
`req_act()` without the `int()` casts the base `TPLinkMRClient` applies.
Since the CGI response is parsed as plain `key=value` text, every field
arrives as a string.

This breaks three consumers:

- `LTEStatus.network_type_info` and `sim_status_info` look up int-keyed
  tables, so `.get('3')` misses and returns "Unknown network type" /
  "Unknown SIM status"
- Downstream `sig_level * 25` becomes string repetition:
  `'4' * 25` -> `'4444444444444444444444444'`

Reproduced with an MR200 via the Home Assistant integration; the MR600
on the same install is fine because it uses the base client's casts.

Before / after with `networkType='3'`, `simStatus='5'`, `signalStrength='4'`:

| | before | after |
|---|---|---|
| network_type_info | `Unknown network type` | `4G LTE` |
| sim_status_info | `Unknown SIM status` | `SIM unlocked. Authentication succeeded.` |
| sig_level * 25 | `'4444444444444444444444444'` | `100` |

### Change

Adds the missing casts, matching `mr.py`. `total_statistics` uses
`int(float(...))` as the base client does. Adds `test_get_lte_status`
covering the MR200 path — it fails on `main` and passes with the fix.