### PR TITLE
feat(deco): expose mesh units via get_mesh_nodes()

### DIFF
--- a/test/test_client_deco.py
+++ b/test/test_client_deco.py
@@ -6,6 +6,7 @@ from tplinkrouterc6u import (
     TPLinkDecoClient,
     Connection,
     Firmware,
+    MeshNode,
     Status,
     Device,
     IPv4Status,
@@ -799,6 +800,105 @@ class TestTPLinkDecoClient(TestCase):
         self.assertEqual(result.lan_macaddr, '44-E1-52-8C-40-37')
         self.assertEqual(result.lan_ipv4_ipaddr, '192.168.68.1')
         self.assertEqual(result.lan_ipv4_netmask, '255.255.255.0')
+
+    def test_get_mesh_nodes(self) -> None:
+        # Captured from a 3-unit Deco X50 mesh on firmware
+        # 1.8.0 Build 25102213 Rel. 43970. Note the master carries no
+        # signal_strength / rx_rate_list / tx_rate_list / previous: it has
+        # no backhaul uplink of its own.
+        response = loads('''
+{"result": {"device_list": [
+        {"role": "slave", "nickname": "Kids", "device_ip": "192.168.71.250",
+        "mac": "F0-09-0D-FA-29-84", "device_model": "X50", "hardware_ver": "1.0",
+        "software_ver": "1.8.0 Build 25102213 Rel. 43970", "inet_status": "online",
+        "group_status": "connected", "previous": "F0-09-0D-FA-29-7C", "port_count": 3,
+        "signal_strength": {"band5": -50, "band2_4": -37},
+        "rx_rate_list": {"band5": 960, "band2_4": 412},
+        "tx_rate_list": {"band5": 1297, "band2_4": 258},
+        "device_type": "HOMEWIFISYSTEM"},
+        {"role": "master", "nickname": "Living Room", "device_ip": "192.168.68.1",
+        "mac": "F0-09-0D-FA-29-7C", "device_model": "X50", "hardware_ver": "1.0",
+        "software_ver": "1.8.0 Build 25102213 Rel. 43970", "inet_status": "online",
+        "group_status": "connected", "previous": "",
+        "signal_level": {"band5": "0", "band2_4": "0"},
+        "device_type": "HOMEWIFISYSTEM"}]},
+"error_code": 0}
+        ''')
+
+        class TPLinkRouterTest(TPLinkDecoClient):
+            def request(self, path: str, data: str,
+                        ignore_response: bool = False, ignore_errors: bool = False) -> dict | None:
+                if path == 'admin/device?form=device_list':
+                    return response['result']
+
+        client = TPLinkRouterTest('', '')
+        result = client.get_mesh_nodes()
+
+        self.assertEqual(len(result), 2)
+        for node in result:
+            self.assertIsInstance(node, MeshNode)
+
+        slave, master = result
+
+        self.assertEqual(slave.nickname, 'Kids')
+        self.assertEqual(slave.role, 'slave')
+        self.assertFalse(slave.is_master)
+        self.assertEqual(slave.macaddr, 'F0-09-0D-FA-29-84')
+        self.assertIsInstance(slave.macaddress, EUI48)
+        self.assertEqual(slave.ipaddr, '192.168.71.250')
+        self.assertIsInstance(slave.ipaddress, IPv4Address)
+        self.assertEqual(slave.model, 'X50')
+        self.assertEqual(slave.hardware_version, '1.0')
+        self.assertEqual(slave.firmware_version, '1.8.0 Build 25102213 Rel. 43970')
+        self.assertEqual(slave.internet_status, 'online')
+        self.assertEqual(slave.group_status, 'connected')
+        self.assertEqual(slave.signal_2g, -37)
+        self.assertEqual(slave.signal_5g, -50)
+        self.assertEqual(slave.rx_rate_2g, 412)
+        self.assertEqual(slave.rx_rate_5g, 960)
+        self.assertEqual(slave.tx_rate_2g, 258)
+        self.assertEqual(slave.tx_rate_5g, 1297)
+        self.assertEqual(slave.parent_macaddr, 'F0-09-0D-FA-29-7C')
+        self.assertEqual(slave.wired_ports, 3)
+
+        self.assertEqual(master.nickname, 'Living Room')
+        self.assertTrue(master.is_master)
+        self.assertEqual(master.ipaddr, '192.168.68.1')
+        # No uplink of its own, so no backhaul metrics and no parent.
+        self.assertIsNone(master.signal_2g)
+        self.assertIsNone(master.signal_5g)
+        self.assertIsNone(master.rx_rate_5g)
+        self.assertIsNone(master.tx_rate_5g)
+        self.assertIsNone(master.parent_macaddr)
+        self.assertIsNone(master.parent_macaddress)
+        self.assertIsNone(master.wired_ports)
+
+    def test_get_mesh_nodes_reuses_cached_device_list(self) -> None:
+        """get_firmware() already fetched the list; do not request it twice."""
+        response = loads('''
+{"result": {"device_list": [
+        {"role": "master", "nickname": "Living Room", "device_ip": "192.168.68.1",
+        "mac": "F0-09-0D-FA-29-7C", "device_model": "X50", "hardware_ver": "1.0",
+        "software_ver": "1.8.0 Build 25102213 Rel. 43970"}]},
+"error_code": 0}
+        ''')
+        calls = []
+
+        class TPLinkRouterTest(TPLinkDecoClient):
+            def request(self, path: str, data: str,
+                        ignore_response: bool = False, ignore_errors: bool = False) -> dict | None:
+                calls.append(path)
+                if path == 'admin/device?form=device_list':
+                    return response['result']
+
+        client = TPLinkRouterTest('', '')
+        client.get_firmware()
+        self.assertEqual(len(calls), 1)
+
+        result = client.get_mesh_nodes()
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].nickname, 'Living Room')
 
 
 if __name__ == '__main__':

--- a/tplinkrouterc6u/__init__.py
+++ b/tplinkrouterc6u/__init__.py
@@ -28,6 +28,7 @@ from tplinkrouterc6u.provider import TplinkRouterProvider
 from tplinkrouterc6u.common.package_enum import Connection, VPN, VpnClientServerProtocol
 from tplinkrouterc6u.common.dataclass import (
     Firmware,
+    MeshNode,
     Status,
     Device,
     IPv4Reservation,

--- a/tplinkrouterc6u/client/deco.py
+++ b/tplinkrouterc6u/client/deco.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from logging import Logger
 from tplinkrouterc6u.common.helper import get_ip, get_mac, get_value
 from tplinkrouterc6u.common.package_enum import Connection
-from tplinkrouterc6u.common.dataclass import Firmware, Status, Device, IPv4Status, LTEStatus
+from tplinkrouterc6u.common.dataclass import Firmware, Status, Device, IPv4Status, LTEStatus, MeshNode
 from tplinkrouterc6u.client_abstract import AbstractRouter
 from tplinkrouterc6u.client.c6u import TplinkEncryption
 
@@ -62,6 +62,54 @@ class TPLinkDecoClient(TplinkEncryption, AbstractRouter):
                                 item.get('software_ver', ''))
 
         return firmware
+
+    def get_mesh_nodes(self) -> list[MeshNode]:
+        """Return every unit of the mesh, master included.
+
+        Reuses the device list ``get_firmware()`` already fetches, which until
+        now kept only the master's firmware and discarded the rest.
+        """
+        if not self.devices:
+            self.get_firmware()
+
+        nodes = []
+        for item in self.devices:
+            signal = item.get('signal_strength') or {}
+            rx = item.get('rx_rate_list') or {}
+            tx = item.get('tx_rate_list') or {}
+            ip = item.get('device_ip')
+            parent = item.get('previous')
+
+            nodes.append(MeshNode(
+                _macaddr=get_mac(item.get('mac')),
+                nickname=item.get('nickname', ''),
+                role=item.get('role', ''),
+                model=item.get('device_model', ''),
+                _ipaddr=get_ip(ip) if ip else None,
+                hardware_version=item.get('hardware_ver'),
+                firmware_version=item.get('software_ver'),
+                internet_status=item.get('inet_status'),
+                group_status=item.get('group_status'),
+                signal_2g=self._to_int(signal.get('band2_4')),
+                signal_5g=self._to_int(signal.get('band5')),
+                rx_rate_2g=self._to_int(rx.get('band2_4')),
+                rx_rate_5g=self._to_int(rx.get('band5')),
+                tx_rate_2g=self._to_int(tx.get('band2_4')),
+                tx_rate_5g=self._to_int(tx.get('band5')),
+                # A master reports an empty 'previous'; only slaves have a parent.
+                _parent_macaddr=get_mac(parent) if parent else None,
+                wired_ports=self._to_int(item.get('port_count')),
+            ))
+
+        return nodes
+
+    @staticmethod
+    def _to_int(value) -> int | None:
+        """The firmware mixes ints and numeric strings across these fields."""
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
 
     def get_status(self) -> Status:
         data = self.request('admin/network?form=wan_ipv4', dumps({'operation': 'read'}))

--- a/tplinkrouterc6u/common/dataclass.py
+++ b/tplinkrouterc6u/common/dataclass.py
@@ -16,6 +16,62 @@ class Firmware:
 
 
 @dataclass
+class MeshNode:
+    """One unit of a mesh system (e.g. a TP-Link Deco).
+
+    The master is the unit the client talks to; every other unit is a slave
+    reached over the backhaul. Signal and rate fields describe that backhaul
+    link and are therefore ``None`` on the master, which has no uplink.
+    """
+
+    _macaddr: EUI48
+    nickname: str
+    role: str
+    model: str
+    _ipaddr: IPv4Address | None = None
+    hardware_version: str | None = None
+    firmware_version: str | None = None
+    internet_status: str | None = None
+    group_status: str | None = None
+    signal_2g: int | None = None
+    signal_5g: int | None = None
+    rx_rate_2g: int | None = None
+    rx_rate_5g: int | None = None
+    tx_rate_2g: int | None = None
+    tx_rate_5g: int | None = None
+    _parent_macaddr: EUI48 | None = None
+    wired_ports: int | None = None
+
+    @property
+    def is_master(self) -> bool:
+        return self.role == 'master'
+
+    @property
+    def macaddr(self) -> str:
+        return str(self._macaddr)
+
+    @property
+    def macaddress(self) -> EUI48:
+        return self._macaddr
+
+    @property
+    def ipaddr(self) -> str | None:
+        return str(self._ipaddr) if self._ipaddr is not None else None
+
+    @property
+    def ipaddress(self) -> IPv4Address | None:
+        return self._ipaddr
+
+    @property
+    def parent_macaddr(self) -> str | None:
+        return str(self._parent_macaddr) if self._parent_macaddr is not None else None
+
+    @property
+    def parent_macaddress(self) -> EUI48 | None:
+        return self._parent_macaddr
+
+
+@dataclass
 class Device:
     type: Connection
     _macaddr: EUI48


### PR DESCRIPTION
## Problem

`TPLinkDecoClient.get_firmware()` reads `admin/device?form=device_list`, which
returns **every unit of the mesh**, but keeps only the master's firmware:

```python
for item in self.devices:
    if item.get('role') != 'master' and len(self.devices) != 1:
        continue          # <- everything about the other units is dropped
```

The data is already fetched and stored in `self.devices` (`reboot()` uses it to
build its `mac_list`), and then discarded. Consumers such as the Home Assistant
integration therefore see a Deco mesh as a single device, and a slave unit that
drops off or degrades is invisible.

## Change

Adds a `MeshNode` dataclass and `TPLinkDecoClient.get_mesh_nodes()`. It reuses
the cached `self.devices`, so **no extra request is made** — it only stops
throwing the data away.

Per unit: `nickname`, `role`, `model`, IP, MAC, hardware/firmware version,
`internet_status`, `group_status`, and for slaves the backhaul metrics
(2.4/5 GHz signal in dBm, rx/tx rates), the parent MAC and the wired port count.

Follows the existing `Device` dataclass conventions: `EUI48`/`IPv4Address` in
private fields with `macaddr`/`ipaddr` string properties alongside
`macaddress`/`ipaddress` typed ones.

A master reports no `signal_strength`, `rx_rate_list`, `tx_rate_list` or
`previous` — it has no uplink of its own — so those fields are `None` there.
The firmware mixes ints and numeric strings across these fields, hence the
`_to_int` guard.

## Testing

Verified against a 3-unit **Deco X50** mesh, firmware
`1.8.0 Build 25102213 Rel. 43970`:

```
[MASTER] Living Room   192.168.68.1
[slave ] Kids          192.168.71.250   5G -50 dBm   rx 960   tx 1441 Mbps
[slave ] Main Bedroom  192.168.71.249   5G -57 dBm   rx 1152  tx 1152 Mbps
```

Both slaves report the master as parent; the master reports none.

- `test_get_mesh_nodes` — real captured payload covering both master and slave,
  asserting every field and that the master's backhaul fields are `None`
- `test_get_mesh_nodes_reuses_cached_device_list` — asserts no second request is
  issued after `get_firmware()`

Full suite passes (512 tests), flake8 clean.

## Note

I have a companion PR ready for `home-assistant-tplink-router` that turns this
into one device per mesh unit with backhaul sensors. Happy to adjust the shape
of `MeshNode` first if you would prefer it modelled differently.
