### PR TITLE
feat(c6u): add delete_ipv4_reservation for Archer routers

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Not every method is available on every client. Methods below `get_ipv6_status` t
 | get_ipv6_status |   | Gets WAN IPv6 status info, gateway, DNS, site prefix (c6u/SG, MR/EX/VR, C80-style; others raise `NotImplementedError`) | [IPv6Status](#IPv6Status) |
 | get_ipv4_reservations |   | Gets IPv4 reserved addresses (static) | [[IPv4Reservation]](#IPv4Reservation) |
 | add_ipv4_reservation | macaddr: str, ipaddr: str, comment: str = '', enable: bool = True | Adds an IPv4 DHCP address reservation |   |
+| delete_ipv4_reservation | macaddr: str | Deletes an IPv4 DHCP address reservation |   |
 | get_ipv4_dhcp_leases |   | Gets IPv4 addresses assigned via DHCP | [[IPv4DHCPLease]](#IPv4DHCPLease) |
 | set_ipv4_dhcps | enable: bool | Turn the LAN IPv4 DHCP server on or off |   |
 | set_wifi | wifi: [Connection](#connection), enable: bool | Turn on/off host, guest, or IoT wifi bands |   |

--- a/test/test_client_c6u.py
+++ b/test/test_client_c6u.py
@@ -1267,6 +1267,47 @@ class TestTPLinkClient(TestCase):
             loads(body['new']),
             {'mac': 'AA-BB-CC-DD-EE-FF', 'ip': '10.0.0.50', 'comment': '', 'enable': 'off'})
 
+    def test_delete_ipv4_reservation(self) -> None:
+        calls = []
+        router_class = self.router_class
+
+        class TPLinkRouterTest(router_class):
+            def request(self, path: str, data: str,
+                        ignore_response: bool = False, ignore_errors: bool = False) -> dict | list | None:
+                calls.append((path, data))
+                if 'operation=load' in path or (data and 'operation=load' in data):
+                    return [
+                        {'mac': '02-00-00-00-00-16', 'ip': '10.0.0.116', 'comment': 'auto', 'enable': 'on'},
+                        {'mac': 'AA-BB-CC-DD-EE-FF', 'ip': '10.0.0.50', 'comment': '', 'enable': 'off'},
+                    ]
+                return None
+
+        client = TPLinkRouterTest('', '')
+        client.delete_ipv4_reservation('aa:bb:cc:dd:ee:ff')
+
+        self.assertEqual(len(calls), 2)
+        load_path, load_data = calls[0]
+        self.assertIn('form=reservation', load_path)
+
+        del_path, del_data = calls[1]
+        self.assertEqual(del_path, 'admin/dhcps?form=reservation')
+        body = dict(parse_qsl(del_data))
+        self.assertEqual(body['operation'], 'remove')
+        self.assertEqual(body['key'], 'AA-BB-CC-DD-EE-FF')
+        self.assertEqual(body['index'], '1')
+
+    def test_delete_ipv4_reservation_not_found(self) -> None:
+        router_class = self.router_class
+
+        class TPLinkRouterTest(router_class):
+            def request(self, path: str, data: str,
+                        ignore_response: bool = False, ignore_errors: bool = False) -> dict | list | None:
+                return [{'mac': '02-00-00-00-00-16', 'ip': '10.0.0.116', 'comment': 'auto', 'enable': 'on'}]
+
+        client = TPLinkRouterTest('', '')
+        with self.assertRaises(ClientException):
+            client.delete_ipv4_reservation('00:11:22:33:44:55')
+
     def test_set_ipv4_dhcps(self) -> None:
         """Read-modify-write of admin/dhcps?form=setting (AX55 capture from PR #199)."""
         setting = {

--- a/tplinkrouterc6u/client/c6u.py
+++ b/tplinkrouterc6u/client/c6u.py
@@ -622,6 +622,25 @@ class TplinkBaseRouter(AbstractRouter, TplinkRequest):
         })
         self.request(path, urlencode({'operation': 'insert', 'new': new}))
 
+    def delete_ipv4_reservation(self, macaddr: str) -> None:
+        """Delete an IPv4 DHCP address reservation.
+
+        macaddr may be given in any common format (colon/dash, upper/lower);
+        it is normalised to the dash-uppercase form the router stores.
+        """
+        raw = self.request(self._url_ipv4_reservations, 'operation=load')
+        items = self._as_list(raw, 'list', 'IPv4 reservation')
+        normalized_mac = str(get_mac(macaddr))
+        target_idx = next(
+            (i for i, item in enumerate(items) if str(get_mac(item.get('mac', ''))) == normalized_mac),
+            None,
+        )
+        if target_idx is None:
+            raise ClientException('Reservation not found for MAC: {}'.format(macaddr))
+
+        path = self._url_ipv4_reservations.split('&operation=')[0]
+        self.request(path, urlencode({'operation': 'remove', 'key': normalized_mac, 'index': target_idx}))
+
     def get_ipv4_dhcp_leases(self) -> [IPv4DHCPLease]:
         dhcp_leases = []
         data = self.request(self._url_ipv4_dhcp_leases, 'operation=load')


### PR DESCRIPTION
## Description
This PR implements `delete_ipv4_reservation(self, macaddr: str) -> None` on `TplinkRouter` (Archer / LuCI routers), complementing the existing `add_ipv4_reservation` and `get_ipv4_reservations` methods.

### Details & Findings
- TP-Link LuCI firmware endpoints for DHCP reservations (`admin/dhcps?form=reservation`) use `operation=remove`.
- LuCI asserts both `key` (normalized uppercase hyphenated MAC) and `index` (0-based integer position in the current reservation list).
- `delete_ipv4_reservation` looks up the entry's position, validates existence (raising `ClientException` if not found), and executes the delete payload `{"operation": "remove", "key": normalized_mac, "index": target_idx}`.

### Verification
- Tested and verified on physical hardware (Archer AXE95) with live add and delete reservation cycles.
- Added unit tests: `test_delete_ipv4_reservation` and `test_delete_ipv4_reservation_not_found` in `test/test_client_c6u.py`.
- All 43 test cases pass; `flake8` clean.
- Updated `README.md` documentation.