### PR TITLE
fix(re330,c80): treat 0000-marker error replies as plain text

### DIFF
--- a/test/test_client_c80.py
+++ b/test/test_client_c80.py
@@ -847,5 +847,24 @@ class TestTplinkC80RouterSslContext(TestCase):
         self.assertIs(client._session.verify, sentinel)
 
 
+class TestTplinkC80RouterDecryptData(TestCase):
+
+    def test_plain_text_with_crlf_is_returned(self) -> None:
+        client = TplinkC80Router('http://192.168.0.1', 'password')
+        text = '00000\r\nid 0|1,0,0\r\nmodelName TL-WR844N'
+        self.assertEqual(client._decrypt_data(text), text)
+
+    def test_bare_ok_marker_is_not_fed_to_base64(self) -> None:
+        """TL-WR844N can answer with a bare '00000' (no CRLF, not base64);
+        it must be returned as-is instead of crashing on b64decode (#59)."""
+        client = TplinkC80Router('http://192.168.0.1', 'password')
+        self.assertEqual(client._decrypt_data('00000'), '00000')
+
+    def test_valid_base64_is_still_decrypted(self) -> None:
+        client = TplinkC80Router('http://192.168.0.1', 'password')
+        encrypted = client._encryption.aes.aes_encrypt('hello world')
+        self.assertEqual(client._decrypt_data(encrypted), 'hello world')
+
+
 if __name__ == '__main__':
     main()

--- a/test/test_client_c80.py
+++ b/test/test_client_c80.py
@@ -860,6 +860,13 @@ class TestTplinkC80RouterDecryptData(TestCase):
         client = TplinkC80Router('http://192.168.0.1', 'password')
         self.assertEqual(client._decrypt_data('00000'), '00000')
 
+    def test_error_code_marker_is_not_fed_to_base64(self) -> None:
+        """The real TL-WR844N answer for get_firmware is '00006\\r\\n'
+        (0000 OK/error marker + error code). It must be returned as-is
+        instead of crashing on b64decode (#59)."""
+        client = TplinkC80Router('http://192.168.0.1', 'password')
+        self.assertEqual(client._decrypt_data('00006\r\n'), '00006\r\n')
+
     def test_valid_base64_is_still_decrypted(self) -> None:
         client = TplinkC80Router('http://192.168.0.1', 'password')
         encrypted = client._encryption.aes.aes_encrypt('hello world')

--- a/test/test_client_re330.py
+++ b/test/test_client_re330.py
@@ -292,5 +292,29 @@ class TestTPLinkClient(TestCase):
         self.assertEqual(led_status, False)
 
 
+class TestTplinkRE330RouterDecryptData(TestCase):
+
+    def test_plain_text_with_crlf_is_returned(self) -> None:
+        client = TplinkRE330Router('http://192.168.0.1', 'password')
+        text = '00000\r\nid 0|1,0,0\r\nmodelName TL-WR844N'
+        self.assertEqual(client._decrypt_data(text), text)
+
+    def test_error_code_marker_is_not_fed_to_base64(self) -> None:
+        """The real TL-WR844N answer for get_firmware is '00006\\r\\n'
+        (0000 OK/error marker + error code). It must be returned as-is
+        instead of crashing on b64decode (#59)."""
+        client = TplinkRE330Router('http://192.168.0.1', 'password')
+        self.assertEqual(client._decrypt_data('00006\r\n'), '00006\r\n')
+
+    def test_bare_ok_marker_is_not_fed_to_base64(self) -> None:
+        client = TplinkRE330Router('http://192.168.0.1', 'password')
+        self.assertEqual(client._decrypt_data('00000'), '00000')
+
+    def test_valid_base64_is_still_decrypted(self) -> None:
+        client = TplinkRE330Router('http://192.168.0.1', 'password')
+        encrypted = client._encryption.aes.aes_encrypt('hello world')
+        self.assertEqual(client._decrypt_data(encrypted), 'hello world')
+
+
 if __name__ == '__main__':
     main()

--- a/test/test_common_helper.py
+++ b/test/test_common_helper.py
@@ -1,6 +1,10 @@
 from unittest import TestCase, main
 
-from tplinkrouterc6u.common.helper import escape_act_attr_value, unescape_act_attr_value
+from tplinkrouterc6u.common.helper import (
+    escape_act_attr_value,
+    unescape_act_attr_value,
+    is_valid_base64,
+)
 
 
 class TestActAttrValueEscaping(TestCase):
@@ -17,6 +21,25 @@ class TestActAttrValueEscaping(TestCase):
     def test_plain_text_unchanged(self) -> None:
         self.assertEqual(escape_act_attr_value('test sms'), 'test sms')
         self.assertEqual(unescape_act_attr_value('test sms'), 'test sms')
+
+
+class TestIsValidBase64(TestCase):
+    def test_valid_base64(self) -> None:
+        self.assertTrue(is_valid_base64('aGVsbG8gd29ybGQ='))
+
+    def test_wrong_length_rejected(self) -> None:
+        self.assertFalse(is_valid_base64('00000'))
+
+    def test_marker_with_crlf_rejected(self) -> None:
+        # "00006\r\n" (WR844N error code) is not valid base64: wrong length
+        # and non-base64 chars.
+        self.assertFalse(is_valid_base64('00006\r\n'))
+
+    def test_non_base64_chars_rejected(self) -> None:
+        self.assertFalse(is_valid_base64('00000foo!@#'))
+
+    def test_padding_validation(self) -> None:
+        self.assertFalse(is_valid_base64('aGVsbG8gd29ybGQ===='))
 
 
 if __name__ == '__main__':

--- a/tplinkrouterc6u/client/c80.py
+++ b/tplinkrouterc6u/client/c80.py
@@ -3,6 +3,7 @@ from urllib import parse
 from collections import defaultdict
 import re
 import requests
+from base64 import b64decode
 from urllib.parse import urlparse
 from requests import Session
 from tplinkrouterc6u.common.helper import get_ip, get_ipv6, get_mac
@@ -516,8 +517,26 @@ class TplinkC80Router(AbstractRouter):
         sign = self._get_signature(len(data))
         return f'sign={sign}\r\ndata={data}'
 
+    @staticmethod
+    def _is_valid_base64(s: str) -> bool:
+        if len(s) % 4 != 0:
+            return False
+        if re.fullmatch(r'[A-Za-z0-9+/]*={0,2}', s) is None:
+            return False
+        try:
+            b64decode(s, validate=True)
+            return True
+        except Exception:
+            return False
+
     def _decrypt_data(self, encrypted_text: str) -> str:
         if isinstance(encrypted_text, str) and encrypted_text.startswith('00000\r\n'):
+            return encrypted_text
+        # A plain-text reply that starts with the OK marker but carries no
+        # base64 payload (e.g. a bare "00000") must not be fed to b64decode
+        # (observed on TL-WR844N, issue #59).
+        if (isinstance(encrypted_text, str) and encrypted_text.startswith('00000')
+                and not self._is_valid_base64(encrypted_text)):
             return encrypted_text
         return self._encryption.aes.aes_decrypt(encrypted_text)
 

--- a/tplinkrouterc6u/client/c80.py
+++ b/tplinkrouterc6u/client/c80.py
@@ -3,10 +3,9 @@ from urllib import parse
 from collections import defaultdict
 import re
 import requests
-from base64 import b64decode
 from urllib.parse import urlparse
 from requests import Session
-from tplinkrouterc6u.common.helper import get_ip, get_ipv6, get_mac
+from tplinkrouterc6u.common.helper import get_ip, get_ipv6, get_mac, is_valid_base64
 from tplinkrouterc6u.common.package_enum import Connection
 from tplinkrouterc6u.common.exception import ClientException
 from tplinkrouterc6u.common.encryption import EncryptionWrapper
@@ -517,27 +516,14 @@ class TplinkC80Router(AbstractRouter):
         sign = self._get_signature(len(data))
         return f'sign={sign}\r\ndata={data}'
 
-    @staticmethod
-    def _is_valid_base64(s: str) -> bool:
-        if len(s) % 4 != 0:
-            return False
-        if re.fullmatch(r'[A-Za-z0-9+/]*={0,2}', s) is None:
-            return False
-        try:
-            b64decode(s, validate=True)
-            return True
-        except Exception:
-            return False
-
     def _decrypt_data(self, encrypted_text: str) -> str:
-        if isinstance(encrypted_text, str) and encrypted_text.startswith('00000\r\n'):
-            return encrypted_text
-        # A plain-text reply that starts with the OK marker but carries no
-        # base64 payload (e.g. a bare "00000") must not be fed to b64decode
-        # (observed on TL-WR844N, issue #59).
-        if (isinstance(encrypted_text, str) and encrypted_text.startswith('00000')
-                and not self._is_valid_base64(encrypted_text)):
-            return encrypted_text
+        # A plain-text reply starts with the 0000 OK/error marker, e.g.
+        # "00000\r\n..." (data) or "00006\r\n" (error code, observed on
+        # TL-WR844N, issue #59). Such replies carry no base64 payload and must
+        # not be fed to b64decode; anything else is encrypted ciphertext.
+        if isinstance(encrypted_text, str) and encrypted_text.startswith('0000'):
+            if not is_valid_base64(encrypted_text):
+                return encrypted_text
         return self._encryption.aes.aes_decrypt(encrypted_text)
 
     def _extract_value(self, response_list, prefix):

--- a/tplinkrouterc6u/client/re330.py
+++ b/tplinkrouterc6u/client/re330.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 import re
 import requests
 from requests import Session
-from tplinkrouterc6u.common.helper import get_ip, get_mac
+from tplinkrouterc6u.common.helper import get_ip, get_mac, is_valid_base64
 from tplinkrouterc6u.common.package_enum import Connection
 from tplinkrouterc6u.common.exception import ClientException
 from tplinkrouterc6u.common.encryption import EncryptionWrapper
@@ -371,6 +371,13 @@ class TplinkRE330Router(AbstractRouter):
         return f'sign={sign}\r\ndata={data}'
 
     def _decrypt_data(self, encrypted_text: str) -> str:
+        # A plain-text reply starts with the 0000 OK/error marker, e.g.
+        # "00000\r\n..." (data) or "00006\r\n" (error code, observed on
+        # TL-WR844N, issue #59). Such replies carry no base64 payload and must
+        # not be fed to b64decode; anything else is encrypted ciphertext.
+        if isinstance(encrypted_text, str) and encrypted_text.startswith('0000'):
+            if not is_valid_base64(encrypted_text):
+                return encrypted_text
         return self._encryption.aes.aes_decrypt(encrypted_text)
 
     def _extract_value(self, response_list, prefix):

--- a/tplinkrouterc6u/common/helper.py
+++ b/tplinkrouterc6u/common/helper.py
@@ -1,5 +1,20 @@
 from ipaddress import IPv4Address, IPv6Address, AddressValueError
 from macaddress import EUI48
+import re
+from base64 import b64decode
+
+
+def is_valid_base64(s: str) -> bool:
+    """Return True if s is a syntactically valid base64 string."""
+    if len(s) % 4 != 0:
+        return False
+    if re.fullmatch(r'[A-Za-z0-9+/]*={0,2}', s) is None:
+        return False
+    try:
+        b64decode(s, validate=True)
+        return True
+    except Exception:
+        return False
 
 
 def get_ip(ip: str) -> IPv4Address:


### PR DESCRIPTION
> *This PR was generated by AI-assisted triage.*

Addresses issue #59 (TL-WR844N).

## Root cause (confirmed with a real response from the reporter)

The WR844N answers `get_firmware()` with **`00006\r\n`** (raw hex `30303030360d0a`) — the `0000` OK/error marker plus an error code — not an encrypted payload. Both the re330 and c80 clients fed such replies to `b64decode()` inside `_decrypt_data()`, crashing with `Invalid base64-encoded string` (5 chars is not a multiple of 4).

The provider currently selects the **re330** client for the WR844N (both classes share the `0000`-style API), so the fix covers both.

## Fix

- Share `is_valid_base64()` in `common/helper.py`.
- `_decrypt_data()` in re330 and c80 now returns any `0000`-prefixed reply that is **not** valid base64 as plain text (covers `00000\r\n...`, bare `00000`, and error codes like `00006\r\n`).
- Encrypted payloads are still decrypted unchanged.

## Tests

- helper: `test_is_valid_base64` (valid / wrong length / CRLF marker / non-base64 chars / padding)
- re330 + c80: `test_plain_text_with_crlf_is_returned`, `test_error_code_marker_is_not_fed_to_base64` (`00006\r\n`), `test_bare_ok_marker_is_not_fed_to_base64`, `test_valid_base64_is_still_decrypted`

Full suite passes (523 tests), flake8 clean.