### PR TITLE
fix: populate TL-SG108E LAN IPv4 address

### DIFF
--- a/test/test_client_sg108e.py
+++ b/test/test_client_sg108e.py
@@ -161,14 +161,16 @@ class TestTPLinkSG108EClient(TestCase):
                 'link_status': [6, 6, 0, 5, 5, 6, 5, 6, 0, 0],
             },
         })
-        # The MAC lookup is best-effort and must not break the port counts.
+        # The MAC/IP lookups are best-effort and must not break the port counts.
         client.device_info = Mock(side_effect=Exception('system info unavailable'))
+        client.ip_settings = Mock(side_effect=Exception('ip settings unavailable'))
 
         status = client.get_status()
         self.assertEqual(status.wired_total, 8)
         # 7 ports link-up (one is down), disabled port ignored.
         self.assertEqual(status.clients_total, 6)
         self.assertIsNone(status.lan_macaddr)
+        self.assertIsNone(status.lan_ipv4_addr)
 
     def test_get_status_populates_lan_macaddr(self) -> None:
         client = TPLinkSG108EClient('http://192.0.2.23', 'password')
@@ -181,10 +183,31 @@ class TestTPLinkSG108EClient(TestCase):
             },
         })
         client.device_info = Mock(return_value={'macStr': '02:00:00:00:00:01'})
+        client.ip_settings = Mock(return_value={})
 
         status = client.get_status()
         # EUI48 stringifies with hyphens in this project.
         self.assertEqual(status.lan_macaddr.lower(), '02-00-00-00-00-01')
+        self.assertIsNone(status.lan_ipv4_addr)
+
+    def test_get_status_populates_lan_ipv4_addr(self) -> None:
+        client = TPLinkSG108EClient('http://192.0.2.23', 'password')
+
+        client.port_stats = Mock(return_value={
+            'max_port_num': 8,
+            'all_info': {
+                'state': [1, 1, 1, 1, 1, 1, 1, 0, 0, 0],
+                'link_status': [6, 6, 0, 5, 5, 6, 5, 6, 0, 0],
+            },
+        })
+        client.device_info = Mock(return_value={'macStr': '02:00:00:00:00:01'})
+        client.ip_settings = Mock(return_value={'ipStr': '192.0.2.23'})
+
+        status = client.get_status()
+        self.assertEqual(status.lan_ipv4_addr, '192.0.2.23')
+        self.assertEqual(status.lan_macaddr.lower(), '02-00-00-00-00-01')
+        self.assertEqual(status.wired_total, 8)
+        self.assertEqual(status.clients_total, 6)
 
     def test_get_port_status_maps_live_tl_sg108e_v6_payloads(self) -> None:
         client = TPLinkSG108EClient('http://192.0.2.23', 'password')

--- a/tplinkrouterc6u/client/sg108e.py
+++ b/tplinkrouterc6u/client/sg108e.py
@@ -135,6 +135,13 @@ class TPLinkSG108EClient(AbstractRouter):
         status.guest_clients_total = 0
         status.devices = []
         status._lan_macaddr = self._resolve_lan_mac()
+        try:
+            settings = self.ip_settings()
+            ip = settings.get("ipStr") or settings.get("ip")
+            if ip:
+                status._lan_ipv4_addr = get_ip(ip)
+        except Exception:
+            pass
 
         return status
 


### PR DESCRIPTION
## Problem

`TPLinkSG108EClient.get_status()` populates the switch port totals and LAN MAC, but leaves `lan_ipv4_addr` unset even though the management address is available from the existing IP settings page.

This prevents consumers from using the existing `Status.lan_ipv4_addr` field for the switch.

## Fix

* Populate `Status._lan_ipv4_addr` from the TL-SG108E IP settings.
* Keep the lookup best-effort so an IP settings failure does not break otherwise valid switch status.
* Add regression coverage for the populated and unavailable cases.

No public API, aggregate semantics, port status behavior, or switch configuration is changed.

## Testing

Tested on:

* TL-SG108E v6.0
* Firmware `1.0.0 Build 20230218 Rel.50633`

Physical switch validation:

* management IPv4 is returned on repeated `get_status()` calls;
* LAN MAC remains populated;
* physical port total remains 8;
* connected-port count remains consistent with per-port link state;
* repeated reads do not change switch configuration.

Also verified:

* `pytest test/test_client_sg108e.py` — 13 passed
* `pytest test` — 537 passed
* flake8 clean
* `git diff --check` clean
* GitHub Actions passed on Python 3.10, 3.11, 3.12, 3.13 and 3.14
