### PR TITLE
Fix get_sms() when message content contains equals sign

### DIFF
--- a/tplinkrouterc6u/client/mr.py
+++ b/tplinkrouterc6u/client/mr.py
@@ -490,10 +490,8 @@ class TPLinkMRClientBase(AbstractRouter):
                         result[index] = obj
                 continue
             if '=' in line:
-                keyval = line.split('=')
-                assert len(keyval) == 2
-
-                obj[keyval[0]] = keyval[1]
+                key, value = line.split('=', 1)
+                obj[key] = value
 
         return result if result else []
 


### PR DESCRIPTION
I ran into this issue when using this library for something because the line could be something like `content=Visit https://example.com/page?id=1`, but I'm a bit of a python noob so let me know if there's better syntax for this.

This library is really awesome btw, thanks for making it.